### PR TITLE
シグナル関連の修正 #20 指摘対応

### DIFF
--- a/src/signal/signal.c
+++ b/src/signal/signal.c
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/22 12:15:51 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/02/22 16:33:02 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/02/23 21:28:04 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,69 +15,52 @@
 #include "signal/signal.h"
 #include <stdlib.h>
 
+void    node_kill(t_node *node)
+{
+    while (node)
+    {
+        if (node->pid > 0)
+            kill(node->pid, SIGKILL);
+        node = node->next;
+    }
+}
+
 void	ctrl_c_handler(int sig)
 {
     (void)sig;
-    g_signal = 1;
+    g_signal = CTRL_C_ONE;
 }
 
 void	ctrl_c_clean_handler(t_minishell *minish)
 {
-    // TODO
-    // プログラム実行していない時
-    // 　node == NULL　の時、終了コード:1
-    // プログラム実行中
-    //   node != NULL の時、終了コード:130
-    // どう分けよう
-    // freeするとabortするのでどうしようかな
     t_node *node;
     node = minish->node;
     g_signal = 0;
     if (node == NULL)
-    {
         minish->status_code = 1;
-    }
     else
     {
-        printf("node->pid: %d\n", node->pid);
-        while (node && node->pid > 0)
-        {
-            kill(node->pid, SIGKILL);
-            node = node->next;
-        }
+        node_kill(node);
         minish->status_code = 130;
-        // free_minishell(minish);
+        free_minishell(minish);
     }
 }
 
 void    ctrl_d_clean_handler(t_minishell *minish)
 {
-    printf("===> ctrl_d_clean_handler\n");
-    // TODO
-    // segfaultするのでどうしようかな
-    // freeがよくわかってない
-    // lsなどが書かれている状態でctrl_dした場合、デフォルトでbashと同じ挙動のため対応なし  
     t_node *node;
     node = minish->node;
-    while (node && node->pid > 0)
-    {
-        kill(node->pid, SIGKILL);
-        node = node->next;
-    }
-    //free_minishell(minish);
-    //exit関数呼び出す？？
-    exit(0);
+    node_kill(node);
+    free_minishell(minish);
+    exit(minish->status_code);
 }
 
 int	signal_monitor()
 {
 	if (g_signal == CTRL_C_ONE)
 	{
-        // 入力中のテキストを破棄、これしないと変にlsとかしてしまう
         rl_delete_text(0, rl_end);
-        // readline()をreturnさせる
         rl_done = 1;
-        // signal_monitorがめちゃくちゃループするので、g_signalを変更する前に処理を書く
         g_signal = CTRL_C_TWO;
 	}
 	return (0);


### PR DESCRIPTION
しょうもないコメントの削除
1.minishell自体の終了ステータスは最後の終了ステータスを返却する必要がある
  → exit時に終了ステータスを返却するように修正
2.パイプの途中にビルトインがある場合、後半がkillされない可能性がある
  → パイプの途中にビルトインがある場合、無視して後続に回す