### PR TITLE
単体テストがエラーになるバグ修正

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,13 @@
 name: Run tests on pull requests to dev
 
-# on:
-#   push:
-#     branches:
-#       - "e2e_test"
 on:
-  pull_request:
+  push:
     branches:
-      - dev
+      - "fix_unit_test"
+# on:
+#   pull_request:
+#     branches:
+#       - dev
 
 jobs:
   build-and-test:
@@ -20,9 +20,8 @@ jobs:
       - name: Build
         run: make
 
-      # ビルドでエラーになってしまう
-      # - name: Run unit tests
-      #   run: make unit_test
+      - name: Run unit tests
+        run: make unit_test
 
       - name: Run E2E tests
         run: make e2e_test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,9 @@
 name: Run tests on pull requests to dev
 
 on:
-  push:
+  pull_request:
     branches:
-      - "fix_unit_test"
-# on:
-#   pull_request:
-#     branches:
-#       - dev
+      - dev
 
 jobs:
   build-and-test:

--- a/libft/ft_lstadd_back.c
+++ b/libft/ft_lstadd_back.c
@@ -6,24 +6,24 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/31 12:01:02 by susumuyagi        #+#    #+#             */
-/*   Updated: 2023/05/31 12:41:53 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/05 12:31:45 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
-void	ft_lstadd_back(t_list **lst, t_list *new)
+void	ft_lstadd_back(t_list **lst, t_list *new_lst)
 {
 	t_list	*last;
 
-	if (!lst || !new)
+	if (!lst || !new_lst)
 		return ;
 	last = ft_lstlast(*lst);
 	if (!last)
 	{
-		*lst = new;
+		*lst = new_lst;
 		return ;
 	}
-	last->next = new;
+	last->next = new_lst;
 	return ;
 }

--- a/libft/ft_lstadd_front.c
+++ b/libft/ft_lstadd_front.c
@@ -6,16 +6,16 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/30 19:07:30 by susumuyagi        #+#    #+#             */
-/*   Updated: 2023/05/31 13:20:25 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/05 12:31:35 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
-void	ft_lstadd_front(t_list **lst, t_list *new)
+void	ft_lstadd_front(t_list **lst, t_list *new_lst)
 {
-	if (!lst || !new)
+	if (!lst || !new_lst)
 		return ;
-	new->next = *lst;
-	*lst = new;
+	new_lst->next = *lst;
+	*lst = new_lst;
 }

--- a/libft/libft.h
+++ b/libft/libft.h
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/18 15:49:00 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/02 16:54:42 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/05 12:32:13 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -72,10 +72,10 @@ void				ft_putstr_fd(char *s, int fd);
 
 // bonus
 t_list				*ft_lstnew(void *content);
-void				ft_lstadd_front(t_list **lst, t_list *new);
+void				ft_lstadd_front(t_list **lst, t_list *new_lst);
 int					ft_lstsize(t_list *lst);
 t_list				*ft_lstlast(t_list *lst);
-void				ft_lstadd_back(t_list **lst, t_list *new);
+void				ft_lstadd_back(t_list **lst, t_list *new_lst);
 void				ft_lstdelone(t_list *lst, void (*del)(void *));
 void				ft_lstclear(t_list **lst, void (*del)(void *));
 void				ft_lstiter(t_list *lst, void (*f)(void *));

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -29,12 +29,12 @@ add_library(libminishell ${LIB_SRCS})
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DREADLINE_LIBRARY -O0 -g")
 include_directories(
-  "${CMAKE_CURRENT_SOURCE_DIR}/../../include" ,
-  "${CMAKE_CURRENT_SOURCE_DIR}/../../libft" ,
+  "${CMAKE_CURRENT_SOURCE_DIR}/../../include"
+  "${CMAKE_CURRENT_SOURCE_DIR}/../../libft"
   "${CMAKE_CURRENT_SOURCE_DIR}/../../readline-8.2"
 )
 link_directories(
-  "${CMAKE_CURRENT_SOURCE_DIR}/../../libft" ,
+  "${CMAKE_CURRENT_SOURCE_DIR}/../../libft"
   "${CMAKE_CURRENT_SOURCE_DIR}/../../readline-8.2"
 )
 target_link_libraries(libminishell ft readline)


### PR DESCRIPTION
libftを追加したタイミングで、単体テストのビルド時にエラーになっていたので修正しました。
ついでにプルリク作成時に単体テストが自動で走るようにしました。