### PR TITLE
変数展開を実装

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
 			"request": "launch",
 			"name": "Debug",
 			"program": "${workspaceFolder}/minishell",
-			// "program": "${workspaceFolder}/test/unit/testBin/env",
+			// "program": "${workspaceFolder}/test/unit/build/bin/expansion",
 			"args": [],
 			"cwd": "${workspaceFolder}",
 			// "stdio": ["${workspaceFolder}/test/e2e/case/status_code.in"]

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ endif
 
 
 SRCS := src/main.c src/minishell.c \
-	src/parser/prompt.c src/parser/lexer.c src/parser/parser.c src/parser/node.c\
+	src/parser/prompt.c src/parser/lexer.c src/parser/parser.c src/parser/node.c src/parser/expansion.c \
 	src/variable/env.c src/variable/var.c \
 	src/exec/exec.c src/exec/find_path.c src/exec/pipe.c src/exec/process.c src/exec/redirect.c src/exec/ft_strsignal.c \
 	src/builtin/builtin.c src/builtin/builtin_echo.c src/builtin/builtin_cd.c src/builtin/builtin_pwd.c src/builtin/builtin_export.c \

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
+/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/14 16:21:32 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/03/07 16:20:42 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/03/11 10:58:38 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,7 +52,11 @@ typedef struct s_minishell
 	int							status_code;
 
 	char						*pwd;
-	//
+
+	// 起動時の引数
+	int							argc;
+	const char					**argv;
+
 	e_error_kind				error_kind;
 }								t_minishell;
 

--- a/include/parser/expansion.h
+++ b/include/parser/expansion.h
@@ -6,21 +6,15 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/07 16:58:41 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/11 11:34:13 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/12 15:12:59 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef EXPANSION_H
 # define EXPANSION_H
 
+# include "minishell.h"
 # include <stddef.h>
-
-typedef enum
-{
-	IN_NONE,
-	IN_QUOTE,
-	IN_D_QUOTE,
-}					e_inside_status;
 
 typedef struct s_expansion
 {

--- a/include/parser/expansion.h
+++ b/include/parser/expansion.h
@@ -1,0 +1,40 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   expansion.h                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/03/07 16:58:41 by susumuyagi        #+#    #+#             */
+/*   Updated: 2024/03/08 17:14:37 by susumuyagi       ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef EXPANSION_H
+# define EXPANSION_H
+
+# include <stddef.h>
+
+typedef enum
+{
+	IN_NONE,
+	IN_QUOTE,
+	IN_D_QUOTE,
+}					e_inside_status;
+
+typedef struct s_expansion
+{
+	char			*ret;
+
+	char			*str;
+	size_t			len;
+
+	size_t			i;
+	size_t			n;
+
+	e_inside_status	in_status;
+}					t_expansion;
+
+char				*expand_str(t_minishell *minish, t_token *tok);
+
+#endif

--- a/include/parser/expansion.h
+++ b/include/parser/expansion.h
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/07 16:58:41 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/08 17:14:37 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/11 11:34:13 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,6 +35,6 @@ typedef struct s_expansion
 	e_inside_status	in_status;
 }					t_expansion;
 
-char				*expand_str(t_minishell *minish, t_token *tok);
+char				*expand(t_minishell *minish, t_token *tok);
 
 #endif

--- a/include/parser/token.h
+++ b/include/parser/token.h
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 14:19:35 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/02/17 16:20:31 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/12 15:17:20 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,13 @@
 # include <stddef.h>
 
 # define CANNOT_TOKENIZE "Error: Cannot tokenize\n"
+
+typedef enum
+{
+	IN_NONE,
+	IN_QUOTE,
+	IN_D_QUOTE,
+}	e_inside_status;
 
 typedef enum
 {

--- a/src/exec/exec.c
+++ b/src/exec/exec.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/19 16:23:27 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/02/28 14:08:56 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/12 17:01:33 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,6 +36,8 @@ void	exec(t_minishell *minish)
 {
 	int	orig_io[2];
 
+	if (minish->node == NULL)
+		return ;
 	set_cmd_path(minish);
 	save_orig_io(orig_io);
 	exec_pipe(minish);

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 13:22:07 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/06 14:00:25 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/11 10:59:30 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,8 +25,9 @@ int	main(int argc, const char **argv, const char **envp)
 {
 	t_minishell	minish;
 
-	(void)argv;
 	init_minishell(&minish);
+	minish.argc = argc;
+	minish.argv = argv;
 	signal(SIGINT, ctrl_c_handler);
 	rl_initialize();
 	rl_event_hook = signal_monitor;

--- a/src/parser/expansion.c
+++ b/src/parser/expansion.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/06 19:45:27 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/08 17:20:24 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/08 17:34:04 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -122,7 +122,7 @@ static void	count_str_none(t_expansion *exp)
 {
 	if (exp->in_status != IN_NONE)
 		return ;
-	while (exp->i < exp->len)
+	while (!done(exp))
 	{
 		if (exp->str[exp->i] == '\'' || exp->str[exp->i] == '\"'
 			|| exp->str[exp->i] == '$')
@@ -137,9 +137,24 @@ static void	count_str_quote(t_expansion *exp)
 {
 	if (exp->in_status != IN_QUOTE)
 		return ;
-	while (exp->i < exp->len)
+	while (!done(exp))
 	{
 		if (exp->str[exp->i] == '\'')
+		{
+			break ;
+		}
+		exp->i++;
+	}
+	return ;
+}
+
+static void	count_str_d_quote(t_expansion *exp)
+{
+	if (exp->in_status != IN_D_QUOTE)
+		return ;
+	while (!done(exp))
+	{
+		if (exp->str[exp->i] == '\"' || exp->str[exp->i] == '$')
 		{
 			break ;
 		}
@@ -189,6 +204,12 @@ int	join_str_quote(t_minishell *minish, t_expansion *exp)
 	return (join_str(minish, exp));
 }
 
+int	join_str_d_quote(t_minishell *minish, t_expansion *exp)
+{
+	count_str_d_quote(exp);
+	return (join_str(minish, exp));
+}
+
 void	update_inside_status(t_expansion *exp)
 {
 	if (exp->str[exp->i] == '\'')
@@ -230,6 +251,8 @@ char	*expand_str(t_minishell *minish, t_token *tok)
 		if (join_str_none(minish, &exp))
 			return (NULL);
 		if (join_str_quote(minish, &exp))
+			return (NULL);
+		if (join_str_d_quote(minish, &exp))
 			return (NULL);
 	}
 	return (exp.ret);

--- a/src/parser/expansion.c
+++ b/src/parser/expansion.c
@@ -1,0 +1,236 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   expansion.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/03/06 19:45:27 by susumuyagi        #+#    #+#             */
+/*   Updated: 2024/03/08 17:20:24 by susumuyagi       ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+#include "minishell.h"
+#include "parser/expansion.h"
+#include <parser/token.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// char	*extract_key(char *str)
+// {
+// }
+
+// char	*special_param(char *s)
+// {
+// 	if (s[0] == '$')
+// 	{
+// 		if (ft_isdigit(s[1]))
+// 		{
+// 			// $0 ~ $9
+// 		}
+// 		else if (s[1] == '#')
+// 		{
+// 			// $#
+// 			// 引数の数
+// 		}
+// 		else if (s[1] == '$')
+// 		{
+// 			// $$
+// 		}
+// 		else if (s[1] == '*')
+// 		{
+// 			// $*
+// 			// 0以外のコマンドライン引数
+// 		}
+// 		else if (s[1] == '@')
+// 		{
+// 			// $@
+// 			// $*と同じ
+// 		}
+// 		else if (s[1] == '?')
+// 		{
+// 			// $?
+// 			// ステータスを返す
+// 		}
+// 		else if (s[1] == '-')
+// 		{
+// 			// $-
+// 			// シェルにセットされているオプションを保持している
+// 		}
+// 		else if (s[1] == '!')
+// 		{
+// 			// $!
+// 			// バックグラウンドで実行された直前のプロセスのプロセス番号を保持しています
+// 		}
+// 	}
+// 	return (NULL);
+// }
+
+static int	init_expansion(t_expansion *exp, t_token *tok)
+{
+	exp->ret = (char *)ft_calloc(1, sizeof(char));
+	if (!exp->ret)
+		return (1);
+	exp->str = tok->str;
+	exp->len = tok->len;
+	exp->i = 0;
+	exp->n = 0;
+	exp->in_status = IN_NONE;
+	return (0);
+}
+
+int	done(t_expansion *exp)
+{
+	return (exp->i >= exp->len);
+}
+
+int	expand_special_param(t_minishell *minish, t_expansion *exp)
+{
+	(void)minish;
+	(void)exp;
+	return (0);
+}
+
+int	expand_variable(t_minishell *minish, t_expansion *exp)
+{
+	(void)minish;
+	(void)exp;
+	return (0);
+}
+
+// else if (s[i + 1] == '_' || ft_isalnum(s[i + 1]))
+// char	*tmp;
+// char	*sparam;
+// if (exp->p[0] == '$' && exp->i + 1 < exp->len)
+// {
+// 	if (exp->p[1] == '_' || ft_isalnum(exp->p[1]))
+// 	{
+// 		// 変数
+// 	}
+// 	else
+// 	{
+// 		// $?
+// 		// ステータスを返す
+// 	}
+// }
+
+// $ ' "
+
+static void	count_str_none(t_expansion *exp)
+{
+	if (exp->in_status != IN_NONE)
+		return ;
+	while (exp->i < exp->len)
+	{
+		if (exp->str[exp->i] == '\'' || exp->str[exp->i] == '\"'
+			|| exp->str[exp->i] == '$')
+		{
+			break ;
+		}
+		exp->i++;
+	}
+}
+
+static void	count_str_quote(t_expansion *exp)
+{
+	if (exp->in_status != IN_QUOTE)
+		return ;
+	while (exp->i < exp->len)
+	{
+		if (exp->str[exp->i] == '\'')
+		{
+			break ;
+		}
+		exp->i++;
+	}
+	return ;
+}
+
+int	join_str(t_minishell *minish, t_expansion *exp)
+{
+	char	*word;
+	char	*tmp;
+	size_t	num;
+
+	num = exp->i - exp->n;
+	if (num > 0)
+	{
+		word = ft_substr(exp->str, exp->n, num);
+		if (!word)
+		{
+			minish->error_kind = ERR_MALLOC;
+			return (1);
+		}
+		tmp = exp->ret;
+		exp->ret = ft_strjoin(exp->ret, word);
+		if (!exp->ret)
+		{
+			minish->error_kind = ERR_MALLOC;
+			free(word);
+			return (1);
+		}
+		exp->n += num;
+		free(tmp);
+	}
+	return (0);
+}
+
+int	join_str_none(t_minishell *minish, t_expansion *exp)
+{
+	count_str_none(exp);
+	return (join_str(minish, exp));
+}
+
+int	join_str_quote(t_minishell *minish, t_expansion *exp)
+{
+	count_str_quote(exp);
+	return (join_str(minish, exp));
+}
+
+void	update_inside_status(t_expansion *exp)
+{
+	if (exp->str[exp->i] == '\'')
+	{
+		if (exp->in_status == IN_NONE)
+			exp->in_status = IN_QUOTE;
+		else if (exp->in_status == IN_QUOTE)
+			exp->in_status = IN_NONE;
+		exp->i++;
+		exp->n++;
+	}
+	else if (exp->str[exp->i] == '\"')
+	{
+		if (exp->in_status == IN_NONE)
+			exp->in_status = IN_D_QUOTE;
+		else if (exp->in_status == IN_D_QUOTE)
+			exp->in_status = IN_NONE;
+		exp->i++;
+		exp->n++;
+	}
+}
+
+char	*expand_str(t_minishell *minish, t_token *tok)
+{
+	t_expansion	exp;
+
+	if (init_expansion(&exp, tok))
+	{
+		minish->error_kind = ERR_MALLOC;
+		return (NULL);
+	}
+	while (!done(&exp))
+	{
+		update_inside_status(&exp);
+		if (expand_special_param(minish, &exp))
+			return (NULL);
+		if (expand_variable(minish, &exp))
+			return (NULL);
+		if (join_str_none(minish, &exp))
+			return (NULL);
+		if (join_str_quote(minish, &exp))
+			return (NULL);
+	}
+	return (exp.ret);
+}

--- a/src/parser/expansion.c
+++ b/src/parser/expansion.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/06 19:45:27 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/08 17:34:04 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/11 15:27:52 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,52 +21,59 @@
 // char	*extract_key(char *str)
 // {
 // }
+//
 
-// char	*special_param(char *s)
-// {
-// 	if (s[0] == '$')
-// 	{
-// 		if (ft_isdigit(s[1]))
-// 		{
-// 			// $0 ~ $9
-// 		}
-// 		else if (s[1] == '#')
-// 		{
-// 			// $#
-// 			// 引数の数
-// 		}
-// 		else if (s[1] == '$')
-// 		{
-// 			// $$
-// 		}
-// 		else if (s[1] == '*')
-// 		{
-// 			// $*
-// 			// 0以外のコマンドライン引数
-// 		}
-// 		else if (s[1] == '@')
-// 		{
-// 			// $@
-// 			// $*と同じ
-// 		}
-// 		else if (s[1] == '?')
-// 		{
-// 			// $?
-// 			// ステータスを返す
-// 		}
-// 		else if (s[1] == '-')
-// 		{
-// 			// $-
-// 			// シェルにセットされているオプションを保持している
-// 		}
-// 		else if (s[1] == '!')
-// 		{
-// 			// $!
-// 			// バックグラウンドで実行された直前のプロセスのプロセス番号を保持しています
-// 		}
-// 	}
-// 	return (NULL);
-// }
+static int	join_var(t_minishell *minish, t_expansion *exp, const char *str,
+		size_t var_len)
+{
+	char	*tmp;
+
+	if (ft_strlen(str) > 0)
+	{
+		tmp = exp->ret;
+		exp->ret = ft_strjoin(exp->ret, str);
+		if (!exp->ret)
+		{
+			minish->error_kind = ERR_MALLOC;
+			return (1);
+		}
+		free(tmp);
+	}
+	exp->i += var_len;
+	exp->n += var_len;
+	return (0);
+}
+
+static int	join_str(t_minishell *minish, t_expansion *exp)
+{
+	char	*word;
+	char	*tmp;
+	size_t	num;
+
+	num = exp->i - exp->n;
+	if (num == 0)
+	{
+		return (0);
+	}
+	word = ft_substr(exp->str, exp->n, num);
+	if (!word)
+	{
+		minish->error_kind = ERR_MALLOC;
+		return (1);
+	}
+	tmp = exp->ret;
+	exp->ret = ft_strjoin(exp->ret, word);
+	if (!exp->ret)
+	{
+		minish->error_kind = ERR_MALLOC;
+		free(word);
+		return (1);
+	}
+	free(word);
+	free(tmp);
+	exp->n += num;
+	return (0);
+}
 
 static int	init_expansion(t_expansion *exp, t_token *tok)
 {
@@ -81,22 +88,83 @@ static int	init_expansion(t_expansion *exp, t_token *tok)
 	return (0);
 }
 
-int	done(t_expansion *exp)
+static int	done(t_expansion *exp)
 {
 	return (exp->i >= exp->len);
 }
 
-int	expand_special_param(t_minishell *minish, t_expansion *exp)
+static int	expand_special_param(t_minishell *minish, t_expansion *exp)
 {
-	(void)minish;
-	(void)exp;
+	int		ret;
+	char	*str;
+
+	if (exp->str[exp->i] != '$')
+	{
+		return (0);
+	}
+	if (exp->str[exp->i + 1] == '0')
+	{
+		// $0
+		return (join_var(minish, exp, minish->argv[0], 2));
+	}
+	else if (ft_isdigit(exp->str[exp->i + 1]))
+	{
+		// $1 ~ $9
+		return (join_var(minish, exp, "", 2));
+	}
+	else if (exp->str[exp->i + 1] == '#')
+	{
+		// $#
+		// 引数の数 minishellは引数を受け付けないため、0固定
+		return (join_var(minish, exp, "0", 2));
+	}
+	else if (exp->str[exp->i + 1] == '$')
+	{
+		// $$ : getpid()が使えないため、何もしない
+		return (0);
+	}
+	else if (exp->str[exp->i + 1] == '*')
+	{
+		// $* : 0以外のコマンドライン引数
+		return (join_var(minish, exp, "", 2));
+	}
+	else if (exp->str[exp->i + 1] == '@')
+	{
+		// $@ : $*と同じ
+		return (join_var(minish, exp, "", 2));
+	}
+	else if (exp->str[exp->i + 1] == '?')
+	{
+		// $? : ステータスを返す
+		str = ft_itoa(minish->status_code);
+		ret = join_var(minish, exp, str, 2);
+		free(str);
+		return (ret);
+	}
+	else if (exp->str[exp->i + 1] == '-')
+	{
+		// $- : // シェルにセットされているオプションを保持している
+		return (join_var(minish, exp, "", 2));
+	}
+	else if (exp->str[exp->i + 1] == '!')
+	{
+		// $! : バックグラウンドで実行された直前のプロセスのプロセス番号を保持しています
+		return (join_var(minish, exp, "0", 2));
+	}
 	return (0);
 }
 
-int	expand_variable(t_minishell *minish, t_expansion *exp)
+static int	expand_variable(t_minishell *minish, t_expansion *exp)
 {
 	(void)minish;
-	(void)exp;
+	if (exp->str[exp->i] != '$')
+	{
+		return (0);
+	}
+	if (exp->str[exp->i + 1] != '\0')
+	{
+		return (0);
+	}
 	return (0);
 }
 
@@ -163,54 +231,25 @@ static void	count_str_d_quote(t_expansion *exp)
 	return ;
 }
 
-int	join_str(t_minishell *minish, t_expansion *exp)
-{
-	char	*word;
-	char	*tmp;
-	size_t	num;
-
-	num = exp->i - exp->n;
-	if (num > 0)
-	{
-		word = ft_substr(exp->str, exp->n, num);
-		if (!word)
-		{
-			minish->error_kind = ERR_MALLOC;
-			return (1);
-		}
-		tmp = exp->ret;
-		exp->ret = ft_strjoin(exp->ret, word);
-		if (!exp->ret)
-		{
-			minish->error_kind = ERR_MALLOC;
-			free(word);
-			return (1);
-		}
-		exp->n += num;
-		free(tmp);
-	}
-	return (0);
-}
-
-int	join_str_none(t_minishell *minish, t_expansion *exp)
+static int	join_str_none(t_minishell *minish, t_expansion *exp)
 {
 	count_str_none(exp);
 	return (join_str(minish, exp));
 }
 
-int	join_str_quote(t_minishell *minish, t_expansion *exp)
+static int	join_str_quote(t_minishell *minish, t_expansion *exp)
 {
 	count_str_quote(exp);
 	return (join_str(minish, exp));
 }
 
-int	join_str_d_quote(t_minishell *minish, t_expansion *exp)
+static int	join_str_d_quote(t_minishell *minish, t_expansion *exp)
 {
 	count_str_d_quote(exp);
 	return (join_str(minish, exp));
 }
 
-void	update_inside_status(t_expansion *exp)
+static void	update_inside_status(t_expansion *exp)
 {
 	if (exp->str[exp->i] == '\'')
 	{
@@ -232,7 +271,7 @@ void	update_inside_status(t_expansion *exp)
 	}
 }
 
-char	*expand_str(t_minishell *minish, t_token *tok)
+char	*expand(t_minishell *minish, t_token *tok)
 {
 	t_expansion	exp;
 

--- a/src/parser/lexer.c
+++ b/src/parser/lexer.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 17:20:20 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/12 15:54:15 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/12 17:25:19 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,6 +47,7 @@ static t_token	*new_token(e_token_kind kind, t_token *cur, char *str,
 	tok->kind = kind;
 	tok->str = str;
 	tok->len = len;
+	tok->next = NULL;
 	cur->next = tok;
 	return (tok);
 }

--- a/src/parser/lexer.c
+++ b/src/parser/lexer.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 17:20:20 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/12 17:25:19 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/12 17:32:57 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -113,7 +113,7 @@ static ssize_t	count_word_len(char *p)
 	if (in_status != IN_NONE)
 	{
 		// "、'が閉じられていない
-		return (-in_status);
+		return (-1);
 	}
 	return (p - q);
 }

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,12 +6,13 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 17:37:32 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/07 11:53:37 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/12 12:39:42 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 #include "minishell.h"
+#include "parser/expansion.h"
 #include "parser/parser.h"
 #include <stdlib.h>
 #include <unistd.h>
@@ -77,9 +78,9 @@ t_node	*malloc_and_init_node(e_node_kind kind)
 t_node	*new_redirect_node(e_node_kind kind, t_minishell *minish)
 {
 	t_node	*node;
-	t_token	*t;
+	t_token	*tok;
 
-	t = minish->cur_token;
+	tok = minish->cur_token;
 	node = malloc_and_init_node(kind);
 	// TODO エラー処理ちゃんと書く
 	if (!node)
@@ -87,9 +88,9 @@ t_node	*new_redirect_node(e_node_kind kind, t_minishell *minish)
 		minish->error_kind = ERR_MALLOC;
 		return (NULL);
 	}
-	node->path = ft_substr(t->str, 0, t->len);
+	node->path = expand(minish, tok);
 	// TODO エラー処理 ft_substrの中でmalloc
-	minish->cur_token = t->next;
+	minish->cur_token = tok->next;
 	return (node);
 }
 
@@ -145,8 +146,7 @@ bool	occurred_syntax_error(t_minishell *minish)
 
 void	put_argv(t_node *node, t_minishell *minish)
 {
-	node->argv[node->argc] = ft_substr(minish->cur_token->str, 0,
-			minish->cur_token->len);
+	node->argv[node->argc] = expand(minish, minish->cur_token);
 	// TODO エラー処理
 	node->argc++;
 	minish->cur_token = minish->cur_token->next;

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 17:37:32 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/02 11:16:49 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/07 11:53:37 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -133,6 +133,7 @@ bool	occurred_syntax_error(t_minishell *minish)
 {
 	if (minish->error_kind == ERR_SYNTAX)
 	{
+		// TODO 後でちゃんと書く
 		ft_printf_fd(STDERR_FILENO, SYNTAX_ERROR);
 		write(STDERR_FILENO, "`", 1);
 		write(STDERR_FILENO, minish->cur_token->str, minish->cur_token->len);

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 17:37:32 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/12 12:39:42 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/12 17:01:06 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -218,18 +218,16 @@ int	parse(t_minishell *minish)
 	t_node	head;
 	t_node	*cur;
 	t_node	*node;
-	int		i;
 
 	minish->error_kind = ERR_NONE;
 	minish->cur_token = minish->token;
+	head.next = NULL;
 	cur = &head;
-	i = 0;
-	while (!at_eof(minish) && !occurred_syntax_error(minish) && i < 5)
+	while (!at_eof(minish) && !occurred_syntax_error(minish))
 	{
 		node = command(minish);
 		cur->next = node;
 		cur = node;
-		i++;
 	}
 	minish->node = head.next;
 	///////////////////////////////////////

--- a/src/parser/prompt.c
+++ b/src/parser/prompt.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 14:13:54 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/04 13:52:41 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/12 17:35:30 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,7 +40,8 @@ void	prompt(t_minishell *minish)
 		return ;
 	}
 	add_history(minish->line);
-	tokenize(minish);
+	if (tokenize(minish))
+		return ;
 	parse(minish);
 	exec(minish);
 	free_minishell(minish);

--- a/test/e2e/case/expansion.in
+++ b/test/e2e/case/expansion.in
@@ -1,0 +1,5 @@
+echo $PWD$HOME'$PATH'--"'$HOME'""'"
+echo $$$PWD
+echo $??$00$11$22$33$-$%
+echo $+
+echo $

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -10,7 +10,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(FetchContent)
 FetchContent_Declare(
   googletest
-  URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG v1.14.0
+  DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 
 # For Windows: Prevent overriding the parent project's compiler/linker settings

--- a/test/unit/src/parser/expansion.cpp
+++ b/test/unit/src/parser/expansion.cpp
@@ -22,17 +22,49 @@ TEST(Expansion, word) {
   EXPECT_STREQ(expected, actual);
 }
 
+TEST(Expansion, nest_quote) {
+  t_minishell minish;
+  t_token tok;
+
+  init_minishell(&minish);
+
+  std::string str = "'\"\"'\"''\"";
+  tok.str = strdup(str.c_str());
+  tok.len = str.size();
+
+  char* expected = "\"\"''";
+  char* actual = expand_str(&minish, &tok);
+
+  EXPECT_STREQ(expected, actual);
+}
+
 TEST(Expansion, quote) {
   t_minishell minish;
   t_token tok;
 
   init_minishell(&minish);
 
-  std::string str = "'12$ENV1%&'abcd!'$ENV2'@#123'$ENV3'";
+  std::string str = "'12$ENV1%&'abcd!'$ENV2'@#123'$ENV3''\"hello\"'";
   tok.str = strdup(str.c_str());
   tok.len = str.size();
 
-  char* expected = "12$ENV1%&abcd!$ENV2@#123$ENV3";
+  char* expected = "12$ENV1%&abcd!$ENV2@#123$ENV3\"hello\"";
+  char* actual = expand_str(&minish, &tok);
+
+  EXPECT_STREQ(expected, actual);
+}
+
+TEST(Expansion, double_quote) {
+  t_minishell minish;
+  t_token tok;
+
+  init_minishell(&minish);
+
+  std::string str = "'12$ENV1%&'abcd!'$ENV2'@#123'$ENV3'\"'hello'\"";
+  tok.str = strdup(str.c_str());
+  tok.len = str.size();
+
+  char* expected = "12$ENV1%&abcd!$ENV2@#123$ENV3'hello'";
   char* actual = expand_str(&minish, &tok);
 
   EXPECT_STREQ(expected, actual);

--- a/test/unit/src/parser/expansion.cpp
+++ b/test/unit/src/parser/expansion.cpp
@@ -1,0 +1,39 @@
+#include <gtest/gtest.h>
+
+extern "C" {
+#include "libft.h"
+#include "minishell.h"
+#include "parser/expansion.h"
+}
+
+TEST(Expansion, word) {
+  t_minishell minish;
+  t_token tok;
+
+  init_minishell(&minish);
+
+  std::string str = "abcd!@#123";
+  tok.str = strdup(str.c_str());
+  tok.len = str.size();
+
+  char* expected = "abcd!@#123";
+  char* actual = expand_str(&minish, &tok);
+
+  EXPECT_STREQ(expected, actual);
+}
+
+TEST(Expansion, quote) {
+  t_minishell minish;
+  t_token tok;
+
+  init_minishell(&minish);
+
+  std::string str = "'12$ENV1%&'abcd!'$ENV2'@#123'$ENV3'";
+  tok.str = strdup(str.c_str());
+  tok.len = str.size();
+
+  char* expected = "12$ENV1%&abcd!$ENV2@#123$ENV3";
+  char* actual = expand_str(&minish, &tok);
+
+  EXPECT_STREQ(expected, actual);
+}

--- a/test/unit/src/parser/expansion.cpp
+++ b/test/unit/src/parser/expansion.cpp
@@ -16,8 +16,8 @@ TEST(Expansion, word) {
   tok.str = strdup(str.c_str());
   tok.len = str.size();
 
-  char* expected = "abcd!@#123";
-  char* actual = expand_str(&minish, &tok);
+  const char* expected = "abcd!@#123";
+  char* actual = expand(&minish, &tok);
 
   EXPECT_STREQ(expected, actual);
 }
@@ -32,8 +32,8 @@ TEST(Expansion, nest_quote) {
   tok.str = strdup(str.c_str());
   tok.len = str.size();
 
-  char* expected = "\"\"''";
-  char* actual = expand_str(&minish, &tok);
+  const char* expected = "\"\"''";
+  char* actual = expand(&minish, &tok);
 
   EXPECT_STREQ(expected, actual);
 }
@@ -48,8 +48,8 @@ TEST(Expansion, quote) {
   tok.str = strdup(str.c_str());
   tok.len = str.size();
 
-  char* expected = "12$ENV1%&abcd!$ENV2@#123$ENV3\"hello\"";
-  char* actual = expand_str(&minish, &tok);
+  const char* expected = "12$ENV1%&abcd!$ENV2@#123$ENV3\"hello\"";
+  char* actual = expand(&minish, &tok);
 
   EXPECT_STREQ(expected, actual);
 }
@@ -64,8 +64,63 @@ TEST(Expansion, double_quote) {
   tok.str = strdup(str.c_str());
   tok.len = str.size();
 
-  char* expected = "12$ENV1%&abcd!$ENV2@#123$ENV3'hello'";
-  char* actual = expand_str(&minish, &tok);
+  const char* expected = "12$ENV1%&abcd!$ENV2@#123$ENV3'hello'";
+  char* actual = expand(&minish, &tok);
+
+  EXPECT_STREQ(expected, actual);
+}
+
+TEST(Expansion, special_param_0_9) {
+  t_minishell minish;
+  t_token tok;
+  const char* argv[] = {"./minishell", NULL};
+
+  init_minishell(&minish);
+  minish.argc = 1;
+  minish.argv = argv;
+
+  std::string str = "abc$00$11$22$33$44$55$66$77$88$99123";
+  tok.str = strdup(str.c_str());
+  tok.len = str.size();
+
+  const char* expected = "abc./minishell0123456789123";
+  char* actual = expand(&minish, &tok);
+
+  EXPECT_STREQ(expected, actual);
+}
+
+TEST(Expansion, special_param_other) {
+  t_minishell minish;
+  t_token tok;
+
+  init_minishell(&minish);
+  minish.status_code = 128;
+
+  std::string str = "aaa$#$*$@$?$-$!aaa";
+  tok.str = strdup(str.c_str());
+  tok.len = str.size();
+
+  const char* expected = "aaa01280aaa";
+  char* actual = expand(&minish, &tok);
+
+  EXPECT_STREQ(expected, actual);
+}
+
+TEST(Expansion, special_param_in_quote_and_d_quote) {
+  t_minishell minish;
+  t_token tok;
+  const char* argv[] = {"./minishell", NULL};
+
+  init_minishell(&minish);
+  minish.argc = 1;
+  minish.argv = argv;
+
+  std::string str = "'abc$00$11$22$33$44'\"$55$66$77$88$99123\"";
+  tok.str = strdup(str.c_str());
+  tok.len = str.size();
+
+  const char* expected = "abc$00$11$22$33$4456789123";
+  char* actual = expand(&minish, &tok);
 
   EXPECT_STREQ(expected, actual);
 }

--- a/test/unit/src/parser/lexer.cpp
+++ b/test/unit/src/parser/lexer.cpp
@@ -115,3 +115,29 @@ TEST(Lexer, nest_quote) {
     EXPECT_EQ(expected_kind[i], actual_kind[i]);
   }
 }
+
+TEST(Lexer, only_space) {
+  t_minishell minish;
+  minish.line = ft_strdup("     \t   ");
+
+  tokenize(&minish);
+
+  std::vector<const char*> expected = {""};
+
+  std::vector<int> expected_kind = {2};
+
+  std::vector<const char*> actual = {};
+  std::vector<int> actual_kind = {};
+
+  for (auto token = minish.token; token; token = token->next) {
+    actual.push_back(strndup(token->str, token->len));
+    actual_kind.push_back(token->kind);
+  }
+
+  ASSERT_EQ(expected.size(), actual.size());
+
+  for (size_t i = 0; i < expected.size(); ++i) {
+    EXPECT_STREQ(expected[i], actual[i]);
+    EXPECT_EQ(expected_kind[i], actual_kind[i]);
+  }
+}

--- a/test/unit/src/parser/lexer.cpp
+++ b/test/unit/src/parser/lexer.cpp
@@ -63,3 +63,55 @@ TEST(Lexer, pipe) {
     EXPECT_EQ(expected_kind[i], actual_kind[i]);
   }
 }
+
+TEST(Lexer, quote_and_d_quote) {
+  t_minishell minish;
+  minish.line = ft_strdup("echo \"ls | cat\"'$PWD'\" > \"' << '");
+
+  tokenize(&minish);
+
+  std::vector<const char*> expected = {"echo",
+                                       "\"ls | cat\"'$PWD'\" > \"' << '", ""};
+  std::vector<int> expected_kind = {1, 1, 2};
+
+  std::vector<const char*> actual = {};
+  std::vector<int> actual_kind = {};
+
+  for (auto token = minish.token; token; token = token->next) {
+    actual.push_back(strndup(token->str, token->len));
+    actual_kind.push_back(token->kind);
+  }
+
+  ASSERT_EQ(expected.size(), actual.size());
+
+  for (size_t i = 0; i < expected.size(); ++i) {
+    EXPECT_STREQ(expected[i], actual[i]);
+    EXPECT_EQ(expected_kind[i], actual_kind[i]);
+  }
+}
+
+TEST(Lexer, nest_quote) {
+  t_minishell minish;
+  minish.line = ft_strdup("\" ' ' \" '\"' \"'\"");
+
+  tokenize(&minish);
+
+  std::vector<const char*> expected = {"\" ' ' \"", "'\"'", "\"'\"", ""};
+
+  std::vector<int> expected_kind = {1, 1, 1, 2};
+
+  std::vector<const char*> actual = {};
+  std::vector<int> actual_kind = {};
+
+  for (auto token = minish.token; token; token = token->next) {
+    actual.push_back(strndup(token->str, token->len));
+    actual_kind.push_back(token->kind);
+  }
+
+  ASSERT_EQ(expected.size(), actual.size());
+
+  for (size_t i = 0; i < expected.size(); ++i) {
+    EXPECT_STREQ(expected[i], actual[i]);
+    EXPECT_EQ(expected_kind[i], actual_kind[i]);
+  }
+}


### PR DESCRIPTION
1. 変数展開を実装しました。
```
echo $?
echo $PWD$HOME
```
などが使えるようになりました。

2. シングルクォーテーション、ダブルクォーテーションもついでに実装しました。
```
echo '$HOME' # 変数展開しな
echo "$HOME" # 変数展開する
```

3. 特殊パラメータについて

- $$ : 本来はpidに変換するべきなのですが、システムコールのgetpidが許可されていないため実装できません。
https://projects.intra.42.fr/projects/42cursus-minishell/projects_users/3134685#team-4949163
このレビューを見た感じ、我々が仕様を決めてよさそうなので、$だけ表示するようになっています。

以下のような動作にしました。
```
echo $$USER
-> $username
echo $$$USER
-> $$username
```

- $-: シェルにセットされているオプションを表示することになっていますが、minishellでオプションなどは実装していないため、何も表示しません