### PR TITLE
signal　禁止関数使用 #24

### DIFF
--- a/include/signal/signal.h
+++ b/include/signal/signal.h
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/22 12:16:18 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/02/22 16:32:48 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/03/18 16:31:52 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,12 +17,10 @@
 # include "readline.h"
 # include <signal.h>
 
-# define CTRL_C_ONE 1
-# define CTRL_C_TWO 2
+# define CTRL_C 1
 
 void	ctrl_c_handler(int sig);
 void	ctrl_c_clean_handler(t_minishell *minish);
 void    ctrl_d_clean_handler(t_minishell *minish);
-int	    signal_monitor(void);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
+/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 13:22:07 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/13 19:36:23 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/18 16:30:37 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,8 +29,6 @@ int	main(int argc, const char **argv, const char **envp)
 	minish.argc = argc;
 	minish.argv = argv;
 	signal(SIGINT, ctrl_c_handler);
-	rl_initialize();
-	rl_event_hook = signal_monitor;
 	if (argc > 1)
 	{
 		ft_printf_fd(STDERR_FILENO, TOO_MANY_ARGS);

--- a/src/parser/prompt.c
+++ b/src/parser/prompt.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   prompt.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
+/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 14:13:54 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/12 17:35:30 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/18 17:10:20 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,12 +29,8 @@ void	prompt(t_minishell *minish)
 		minish->line = get_next_line(0);
 	if (minish->line == NULL)
 		ctrl_d_clean_handler(minish);
-	if (g_signal == CTRL_C_TWO)
+	if (g_signal == CTRL_C)
 		ctrl_c_clean_handler(minish);
-	// debug //////////////////////////////////////
-	// TODO 後で消す
-	// printf("minish->status_code: %d\n", minish->status_code);
-	///////////////////////////////////////////////
 	if (ft_strlen(minish->line) == 0)
 	{
 		return ;

--- a/src/signal/signal.c
+++ b/src/signal/signal.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   signal.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
+/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/22 12:15:51 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/03/05 14:45:45 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/18 17:09:44 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,11 @@ void	node_kill(t_node *node)
 void	ctrl_c_handler(int sig)
 {
 	(void)sig;
-	g_signal = CTRL_C_ONE;
+	rl_on_new_line();
+	ft_printf_fd(STDOUT_FILENO, "\n");
+	rl_replace_line("", 0);
+	rl_redisplay();
+	g_signal = CTRL_C;
 }
 
 void	ctrl_c_clean_handler(t_minishell *minish)
@@ -55,15 +59,4 @@ void	ctrl_d_clean_handler(t_minishell *minish)
 	node_kill(node);
 	die_minishell(minish);
 	exit(minish->status_code);
-}
-
-int	signal_monitor(void)
-{
-	if (g_signal == CTRL_C_ONE)
-	{
-		rl_delete_text(0, rl_end);
-		rl_done = 1;
-		g_signal = CTRL_C_TWO;
-	}
-	return (0);
 }


### PR DESCRIPTION
- 禁止されているhook等削除しました
- ctrl + dの挙動差異
bashはexitを出力しますが、minishellは何も出力しません。
```
bash-3.2$ exit
minishell $ 
```
readllineでctrl+dを入力するとNULLを受け取って実装したhandlerでexitを出力しようとしましたが、readline側で改行を入れる処理をしていそうで、以下の出力になります。
```
minishell $ 
exit
```
readline側のhook（rl_bind_key等）でどうにかするのかと思いますが、使用関数に含まれないので対応せずディフェンスします。
