### PR TITLE
73 ctrl cの時プロンプトの表示がおかしい

### DIFF
--- a/src/exec/process.c
+++ b/src/exec/process.c
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/12 12:06:41 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/19 17:02:27 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/03/23 17:24:03 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -76,11 +76,10 @@ void	wait_prosesses(t_minishell *minish)
 		}
 		else if (WIFSIGNALED(node->wait_status))
 		{
-			ft_printf_fd(STDERR_FILENO, "%s: %d\n",
-				ft_strsignal(WTERMSIG(node->wait_status)),
-				WTERMSIG(node->wait_status));
+			if (node->next == NULL)
+				ft_printf_fd(STDERR_FILENO, "\n");
+			// ctrl_cだと2と128論理和の計算で130にしている
 			node->wait_status |= 128;
-			// exit(node->wait_status);
 		}
 		else if (WIFSTOPPED(node->wait_status))
 		{

--- a/src/exec/process.c
+++ b/src/exec/process.c
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/12 12:06:41 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/23 17:24:03 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/03/25 13:52:43 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -77,8 +77,11 @@ void	wait_prosesses(t_minishell *minish)
 		else if (WIFSIGNALED(node->wait_status))
 		{
 			if (node->next == NULL)
-				ft_printf_fd(STDERR_FILENO, "\n");
-			// ctrl_cだと2と128論理和の計算で130にしている
+			{
+				ft_printf_fd(STDERR_FILENO, "%s: %d\n",
+					ft_strsignal(WTERMSIG(node->wait_status)),
+					WTERMSIG(node->wait_status));
+			}
 			node->wait_status |= 128;
 		}
 		else if (WIFSTOPPED(node->wait_status))

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 13:22:07 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/19 17:18:14 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/03/21 19:18:02 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,11 @@
 // 	system("leaks -q minishell");
 // }
 
+int	event(void)
+{
+	return (0);
+}
+
 int	main(int argc, const char **argv, const char **envp)
 {
 	t_minishell	minish;
@@ -30,6 +35,9 @@ int	main(int argc, const char **argv, const char **envp)
 	minish.argc = argc;
 	minish.argv = argv;
 	signal(SIGINT, ctrl_c_handler);
+	// hookを設定することでrl_doneが効くようになったのでreadlineから抜けることができる
+	// hookはwebに上がっているminishellでも使っているので使っても良いかも使える理由を探し中
+	rl_event_hook = event;
 	if (argc > 1)
 	{
 		ft_printf_fd(STDERR_FILENO, TOO_MANY_ARGS);

--- a/src/parser/heredoc.c
+++ b/src/parser/heredoc.c
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/15 15:43:15 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/21 19:10:54 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/03/25 13:12:25 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -85,12 +85,12 @@ void	read_heredoc(t_minishell *minish, int idx)
 	{
 		line = readline(HEREDOC_PROMPT);
 		// ctrl + Dの場合
-		if (line == NULL || ft_strcmp(line, "") == 0)
+		if (line == NULL)
 		{
 			break ;
 		}
 		// ctrl + Cの場合
-		if (ft_strcmp(line, "") == 0)
+		if (ft_strlen(line) == 0)
 		{
 			doc = NULL;
 			break ;

--- a/src/parser/heredoc.c
+++ b/src/parser/heredoc.c
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/15 15:43:15 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/19 17:16:56 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/03/21 19:10:54 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -84,8 +84,15 @@ void	read_heredoc(t_minishell *minish, int idx)
 	while (1)
 	{
 		line = readline(HEREDOC_PROMPT);
-		if (line == NULL)
+		// ctrl + Dの場合
+		if (line == NULL || ft_strcmp(line, "") == 0)
 		{
+			break ;
+		}
+		// ctrl + Cの場合
+		if (ft_strcmp(line, "") == 0)
+		{
+			doc = NULL;
 			break ;
 		}
 		// 終端文字列の場合

--- a/src/parser/prompt.c
+++ b/src/parser/prompt.c
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 14:13:54 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/19 17:15:19 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/03/21 19:11:57 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,7 +30,7 @@ void	prompt(t_minishell *minish)
 		minish->line = get_next_line(0);
 	if (minish->line == NULL)
 		ctrl_d_clean_handler(minish);
-	if (g_signal == CTRL_C)
+	else if (ft_strcmp(minish->line, "") == 0)
 		ctrl_c_clean_handler(minish);
 	if (ft_strlen(minish->line) == 0)
 	{

--- a/src/signal/signal.c
+++ b/src/signal/signal.c
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/22 12:15:51 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/03/18 17:09:44 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/03/21 19:12:51 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,11 +28,10 @@ void	node_kill(t_node *node)
 void	ctrl_c_handler(int sig)
 {
 	(void)sig;
-	rl_on_new_line();
-	ft_printf_fd(STDOUT_FILENO, "\n");
-	rl_replace_line("", 0);
-	rl_redisplay();
+	// なぜかg_signalの値が更新されない...
 	g_signal = CTRL_C;
+	rl_replace_line("", 0);
+	rl_done = 1;
 }
 
 void	ctrl_c_clean_handler(t_minishell *minish)


### PR DESCRIPTION
- ctrl Cが押された時、readlineをreturnするように修正
- heredocでctrl Cが押された場合、docをNULLにして即returnするように修正
- waitpidから返ってきたwait_statusの値によって分岐している箇所を修正