### PR TITLE
構文エラー実装

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
+/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/14 16:21:32 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/03/19 16:58:38 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/03/26 21:02:37 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,6 +20,8 @@
 # include <signal.h>
 # include <stdbool.h>
 # include <stdio.h>
+
+# define NO_ERROR(minish) ((minish)->error_kind == ERR_NONE)
 
 // シグナル用グローバル変数
 static volatile sig_atomic_t	g_signal;

--- a/src/parser/prompt.c
+++ b/src/parser/prompt.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   prompt.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
+/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 14:13:54 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/21 19:11:57 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/03/26 21:28:56 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,13 +33,12 @@ void	prompt(t_minishell *minish)
 	else if (ft_strcmp(minish->line, "") == 0)
 		ctrl_c_clean_handler(minish);
 	if (ft_strlen(minish->line) == 0)
-	{
-		return ;
-	}
+		return (free_minishell(minish));
 	add_history(minish->line);
 	if (tokenize(minish))
-		return ;
-	parse(minish);
+		return (free_minishell(minish));
+	if (parse(minish))
+		return (free_minishell(minish));
 	exec(minish);
 	free_minishell(minish);
 }


### PR DESCRIPTION
構文エラーを実装しました。
```
minishell $ |
minishell: syntax error near unexpected token `|'
minishell $ | ls
minishell: syntax error near unexpected token `|'
minishell $ ls |  | cat
minishell: syntax error near unexpected token `|'
minishell $ << <
minishell: syntax error near unexpected token `<'
minishell $ >> >
minishell: syntax error near unexpected token `>'
minishell $ > >
minishell: syntax error near unexpected token `>'
minishell $ < >
minishell: syntax error near unexpected token `>'
```
など

これはbashではエラーではありませんが、minishellではエラーにしています。
```
minishell $ ls |
minishell: syntax error near unexpected token `|'
```
