### PR TITLE
Fix #78 heredoc時にCtrl-c押した時の挙動を修正

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/14 16:21:32 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/03/26 21:02:37 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/27 11:05:36 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,6 +31,7 @@ typedef enum
 	ERR_NONE,
 	ERR_SYNTAX,
 	ERR_MALLOC,
+	INTERRUPT,
 }								e_error_kind;
 
 typedef struct s_minishell

--- a/src/parser/heredoc.c
+++ b/src/parser/heredoc.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   heredoc.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
+/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/15 15:43:15 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/25 13:12:25 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/03/27 11:06:18 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -92,6 +92,8 @@ void	read_heredoc(t_minishell *minish, int idx)
 		// ctrl + Cの場合
 		if (ft_strlen(line) == 0)
 		{
+			free(doc);
+			free(line);
 			doc = NULL;
 			break ;
 		}
@@ -140,6 +142,12 @@ void	input_heredoc(t_minishell *minish)
 	while (i < minish->heredoc.num)
 	{
 		read_heredoc(minish, i);
+		if (minish->heredoc.docs[i] == NULL)
+		{
+			minish->error_kind = INTERRUPT;
+			minish->status_code = 1;
+			return ;
+		}
 		i++;
 	}
 }

--- a/src/parser/node.c
+++ b/src/parser/node.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/02 17:09:54 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/13 19:34:27 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/27 13:13:10 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,7 @@ static void	free_redirect(t_node *node)
 
 	while (node)
 	{
-		tmp = node->redirect;
+		tmp = node->next;
 		free_array((void **)node->argv);
 		free(node->path);
 		free(node);


### PR DESCRIPTION
fix #78

- heredocでCtrl-c押した時、終了ステータスを1にしました。
- 複数heredocがある場合でもCtrl-cを押したら、プロンプトに戻る様にしました。
  （以前は全てのheredocを読み込まないとプロンプトに戻れなかった）
- ついでに複数リダイレクト or heredocがある場合、メモリリークするバグを修正しました。
