### PR TITLE
unset PATHした時のエラーメッセージ修正

### DIFF
--- a/include/exec/process.h
+++ b/include/exec/process.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   process.h                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
+/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 14:19:35 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/19 16:54:27 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/03/28 14:39:02 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,7 +16,7 @@
 # include "minishell.h"
 # include "parser/node.h"
 
-void	exec_cmd(t_node *node, char **envp);
+void	exec_cmd(t_node *node, char **envp, char *path);
 t_node	*parent_process(t_node *node, int prev_fds[]);
 void	wait_prosesses(t_minishell *minish);
 void	set_status_code(t_minishell *minish);

--- a/src/exec/pipe.c
+++ b/src/exec/pipe.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/12 12:06:41 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/19 17:59:57 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/28 14:32:59 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -132,7 +132,7 @@ void	exec_pipe(t_minishell *minish)
 		else
 		{
 			envp = get_envp(minish);
-			exec_cmd(node, envp);
+			exec_cmd(node, envp, get_var(minish, "PATH"));
 		}
 	}
 }

--- a/src/exec/process.c
+++ b/src/exec/process.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/12 12:06:41 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/27 16:23:44 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/28 14:37:59 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,18 +18,20 @@
 #include "minishell.h"
 #include "parser/node.h"
 #include "utils/exit_status.h"
+#include "variable/env.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
-void	exec_cmd(t_node *node, char **envp)
+void	exec_cmd(t_node *node, char **envp, char *path)
 {
 	if (node->argv[0] == NULL)
 		exit(EXIT_SUCCESS);
 	if (!node->exist_cmd)
 	{
-		if (ft_strchr(node->argv[0], '/'))
+		if (ft_strchr(node->argv[0], '/') || path == NULL
+			|| ft_strlen(path) == 0)
 		{
 			ft_printf_fd(STDERR_FILENO, MINISHELL_ERROR, node->argv[0],
 				NO_SUCH_FILE_OR_DIR);


### PR DESCRIPTION
PATHがNULLの場合、PATHが空文字("")の場合のエラーメッセージを
No such file or directoryにしました

```
minishell $ unset PATH
minishell $ ls
minishell: ls: No such file or directory

minishell $ PATH=
minishell $ ls
minishell: ls: No such file or directory

minishell $ PATH=.
minishell $ ls
minishell: ls: command not found
```
fix #65
