### PR TITLE
変数展開した後に空白区切りがある場合に対応しました 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ SRCS := src/main.c src/minishell.c \
 	src/builtin/builtin.c src/builtin/builtin_echo.c src/builtin/builtin_cd.c src/builtin/builtin_pwd.c src/builtin/builtin_export.c \
 	src/builtin/builtin_unset.c src/builtin/builtin_env.c src/builtin/builtin_exit.c src/builtin/builtin_var.c \
   	src/signal/signal.c \
-	src/utils/utils.c
+	src/utils/utils.c src/utils/minishell_error.c
 OBJS := $(SRCS:.c=.o)
 
 all: $(NAME)

--- a/include/message/message.h
+++ b/include/message/message.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   message.h                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
+/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/19 16:45:14 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/03/26 15:01:55 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/03/28 12:36:08 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,7 @@
 # define MESSAGE_H
 
 # define MINISHELL_ERROR "minishell: %s: %s\n"
+# define MINISHELL_NAME "minishell: "
 
 // --- builtin ---
 # define BUILTIN_ERROR "minishell: %s: %s: %s\n"
@@ -31,10 +32,10 @@
 // --- parser ---
 # define SYNTAX_ERROR "minishell: syntax error near unexpected token "
 # define PROMPT "minishell $ "
-# define READ_ERR "Error: Can not read line\n"
 # define ERROR_MAX_HEREDOC "minishell: maximum here-document count exceeded"
 # define HEREDOC_PROMPT "> "
 # define CANNOT_TOKENIZE "Error: Cannot tokenize\n"
+# define AMBIGUOUS_REDIRECT ": ambiguous redirect\n"
 
 // --- minishell ---
 # define TOO_MANY_ARGS "Error: too many arguments\n"

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/14 16:21:32 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/03/27 11:05:36 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/28 16:53:47 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,6 +31,7 @@ typedef enum
 	ERR_NONE,
 	ERR_SYNTAX,
 	ERR_MALLOC,
+	ERR_REDIRECT,
 	INTERRUPT,
 }								e_error_kind;
 

--- a/include/parser/expansion.h
+++ b/include/parser/expansion.h
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/07 16:58:41 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/27 17:12:08 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/29 12:01:49 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,6 +31,7 @@ typedef struct s_expansion
 
 char				*expand(t_minishell *minish, t_token *tok);
 char				*expand_redirect(t_minishell *minish, t_token *tok);
+char				**expand_argv(t_minishell *minish, t_token *tok);
 char				*expand_delimiter(t_minishell *minish, t_token *tok);
 char				*expand_heredoc(t_minishell *minish, const char *str);
 

--- a/include/parser/expansion.h
+++ b/include/parser/expansion.h
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/07 16:58:41 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/18 17:22:57 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/27 17:12:08 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,6 +30,7 @@ typedef struct s_expansion
 }					t_expansion;
 
 char				*expand(t_minishell *minish, t_token *tok);
+char				*expand_redirect(t_minishell *minish, t_token *tok);
 char				*expand_delimiter(t_minishell *minish, t_token *tok);
 char				*expand_heredoc(t_minishell *minish, const char *str);
 

--- a/include/utils/minishell_error.h
+++ b/include/utils/minishell_error.h
@@ -1,0 +1,20 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   minishell_error.h                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/03/28 16:53:52 by susumuyagi        #+#    #+#             */
+/*   Updated: 2024/03/28 17:02:22 by susumuyagi       ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef MINISHELL_ERROR_H
+# define MINISHELL_ERROR_H
+
+# include "minishell.h"
+
+void	occurred_redirect_error(t_minishell *minish, t_token *tok);
+
+#endif

--- a/libft/Makefile
+++ b/libft/Makefile
@@ -6,7 +6,7 @@ SRCS=ft_atoi.c ft_calloc.c \
 	ft_strlen.c ft_strlcpy.c ft_strlcat.c ft_strchr.c ft_strrchr.c ft_strncmp.c ft_strnstr.c ft_strdup.c \
 	ft_toupper.c ft_tolower.c \
 	ft_itoa.c ft_putchar_fd.c ft_putstr_fd.c ft_putendl_fd.c ft_putnbr_fd.c \
-	ft_substr.c ft_strjoin.c ft_strtrim.c ft_split.c ft_strmapi.c ft_striteri.c \
+	ft_substr.c ft_strjoin.c ft_strtrim.c ft_split.c ft_split2.c ft_strmapi.c ft_striteri.c \
 	ft_lstnew.c ft_lstadd_front.c ft_lstsize.c ft_lstlast.c ft_lstadd_back.c \
 	ft_lstdelone.c ft_lstclear.c ft_lstiter.c ft_lstmap.c \
 	ft_printf.c ft_puthex_utils.c ft_putnbr_utils.c ft_putstr_utils.c \

--- a/libft/ft_split2.c
+++ b/libft/ft_split2.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/22 17:21:42 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/28 17:54:27 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/29 14:14:10 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
-static bool	is_delimiter(char c, char *delimiters)
+static bool	is_delimiter(char c, const char *delimiters)
 {
 	while (*delimiters)
 	{
@@ -25,7 +25,7 @@ static bool	is_delimiter(char c, char *delimiters)
 	return (false);
 }
 
-static char	**malloc_ret(char const *s, char *c)
+static char	**malloc_ret(char const *s, const char *c)
 {
 	size_t	count;
 	size_t	i;
@@ -48,7 +48,7 @@ static char	**malloc_ret(char const *s, char *c)
 	return (ret);
 }
 
-static size_t	word_len(char const *s, char *c, size_t i)
+static size_t	word_len(char const *s, const char *c, size_t i)
 {
 	size_t	count;
 
@@ -74,7 +74,7 @@ static void	free_ret(char **ret, size_t k)
 	free(ret);
 }
 
-static int	split(char const *s, char *c, char **ret)
+static int	split(char const *s, const char *c, char **ret)
 {
 	size_t	i;
 	size_t	k;

--- a/libft/ft_split2.c
+++ b/libft/ft_split2.c
@@ -1,0 +1,119 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_split2.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/05/22 17:21:42 by susumuyagi        #+#    #+#             */
+/*   Updated: 2024/03/28 17:54:27 by susumuyagi       ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+#include <stdbool.h>
+#include <stdlib.h>
+
+static bool	is_delimiter(char c, char *delimiters)
+{
+	while (*delimiters)
+	{
+		if (c == *delimiters)
+			return (true);
+		delimiters++;
+	}
+	return (false);
+}
+
+static char	**malloc_ret(char const *s, char *c)
+{
+	size_t	count;
+	size_t	i;
+	char	**ret;
+
+	count = 0;
+	i = 0;
+	while (s[i])
+	{
+		if (i == 0 && !is_delimiter(s[0], c))
+			count++;
+		else if (is_delimiter(s[i - 1], c) && !is_delimiter(s[i], c))
+			count++;
+		i++;
+	}
+	ret = (char **)malloc(sizeof(char *) * (count + 1));
+	if (!ret)
+		return (NULL);
+	ret[count] = NULL;
+	return (ret);
+}
+
+static size_t	word_len(char const *s, char *c, size_t i)
+{
+	size_t	count;
+
+	count = 0;
+	while (s[i] && !is_delimiter(s[i], c))
+	{
+		count++;
+		i++;
+	}
+	return (count);
+}
+
+static void	free_ret(char **ret, size_t k)
+{
+	size_t	i;
+
+	i = 0;
+	while (i < k)
+	{
+		free(ret[i]);
+		i++;
+	}
+	free(ret);
+}
+
+static int	split(char const *s, char *c, char **ret)
+{
+	size_t	i;
+	size_t	k;
+	size_t	len;
+	char	*word;
+
+	i = 0;
+	k = 0;
+	while (s[i])
+	{
+		len = 0;
+		if ((i == 0 && !is_delimiter(s[i], c)) || (is_delimiter(s[i - 1], c)
+				&& !is_delimiter(s[i], c)))
+			len = word_len(s, c, i);
+		if (len > 0)
+		{
+			word = ft_substr(s, i, len);
+			if (!word)
+			{
+				free_ret(ret, k);
+				return (0);
+			}
+			ret[k++] = word;
+		}
+		i++;
+	}
+	return (1);
+}
+
+char	**ft_split2(char const *s, const char *c)
+{
+	char	**ret;
+
+	if (!s)
+		return (NULL);
+	ret = malloc_ret(s, c);
+	if (!ret)
+		return (NULL);
+	if (!split(s, c, ret))
+		return (NULL);
+	return (ret);
+}

--- a/libft/libft.h
+++ b/libft/libft.h
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/18 15:49:00 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/18 17:46:49 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/28 17:54:35 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -100,6 +100,7 @@ int					ft_printf_fd(int fd, const char *fmt, ...);
 int					ft_isspace(int c);
 int					ft_ispunct(int c);
 char				*ft_join_words(int n, ...);
+char				**ft_split2(char const *s, const char *c);
 
 // get_next_line
 # ifndef BUFFER_SIZE

--- a/src/parser/expansion.c
+++ b/src/parser/expansion.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/06 19:45:27 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/28 17:02:56 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/29 11:57:29 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -368,6 +368,36 @@ static bool	has_quotes(t_token *tok)
 	has_s_quote = ft_memchr(tok->str, '\'', tok->len) != NULL;
 	has_d_quote = ft_memchr(tok->str, '\"', tok->len) != NULL;
 	return (has_s_quote || has_d_quote);
+}
+
+char	**expand_argv(t_minishell *minish, t_token *tok)
+{
+	char	**ret;
+	char	*expanded;
+
+	expanded = expand(minish, tok);
+	if (!expanded)
+		return (NULL);
+	if (has_quotes(tok))
+	{
+		ret = (char **)ft_calloc(2, sizeof(char *));
+		if (!ret)
+		{
+			minish->error_kind = ERR_MALLOC;
+			free(expanded);
+			return (NULL);
+		}
+		ret[0] = expanded;
+		return (ret);
+	}
+	ret = ft_split2(expanded, " \t");
+	free(expanded);
+	if (!ret)
+	{
+		minish->error_kind = ERR_MALLOC;
+		return (NULL);
+	}
+	return (ret);
 }
 
 char	*expand_redirect(t_minishell *minish, t_token *tok)

--- a/src/parser/expansion.c
+++ b/src/parser/expansion.c
@@ -6,13 +6,14 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/06 19:45:27 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/18 17:18:02 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/28 17:02:56 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 #include "minishell.h"
 #include "parser/expansion.h"
+#include "utils/minishell_error.h"
 #include "variable/env.h"
 #include <parser/token.h>
 #include <stddef.h>
@@ -357,6 +358,43 @@ char	*expand(t_minishell *minish, t_token *tok)
 			return (NULL);
 	}
 	return (exp.ret);
+}
+
+static bool	has_quotes(t_token *tok)
+{
+	bool	has_s_quote;
+	bool	has_d_quote;
+
+	has_s_quote = ft_memchr(tok->str, '\'', tok->len) != NULL;
+	has_d_quote = ft_memchr(tok->str, '\"', tok->len) != NULL;
+	return (has_s_quote || has_d_quote);
+}
+
+char	*expand_redirect(t_minishell *minish, t_token *tok)
+{
+	char	*ret;
+	char	*tmp;
+
+	ret = expand(minish, tok);
+	if (!ret)
+		return (NULL);
+	if (has_quotes(tok))
+		return (ret);
+	tmp = ret;
+	ret = ft_strtrim(ret, " \t");
+	free(tmp);
+	if (!ret)
+	{
+		minish->error_kind = ERR_MALLOC;
+		return (NULL);
+	}
+	if (ft_strchr(ret, ' ') != NULL || ft_strchr(ret, '\t') != NULL)
+	{
+		occurred_redirect_error(minish, tok);
+		free(ret);
+		return (NULL);
+	}
+	return (ret);
 }
 
 char	*expand_delimiter(t_minishell *minish, t_token *tok)

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 17:37:32 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/28 12:32:02 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/29 12:00:59 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -190,9 +190,20 @@ static bool	expect_word(t_minishell *minish)
 
 static void	put_argv(t_node *node, t_minishell *minish)
 {
-	node->argv[node->argc] = expand(minish, minish->cur_token);
-	// TODO エラー処理
-	node->argc++;
+	char	**argv;
+	int		i;
+
+	argv = expand_argv(minish, minish->cur_token);
+	if (!argv)
+		return ;
+	i = 0;
+	while (argv[i])
+	{
+		node->argv[node->argc] = argv[i];
+		node->argc++;
+		i++;
+	}
+	free(argv);
 	minish->cur_token = minish->cur_token->next;
 }
 

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 17:37:32 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/27 10:20:43 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/28 12:32:02 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -111,8 +111,7 @@ static t_node	*new_redirect_node(e_node_kind kind, t_minishell *minish)
 	}
 	else
 	{
-		node->path = expand(minish, tok);
-		// TODO エラー処理
+		node->path = expand_redirect(minish, tok);
 	}
 	minish->cur_token = tok->next;
 	return (node);

--- a/src/utils/minishell_error.c
+++ b/src/utils/minishell_error.c
@@ -1,0 +1,25 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   minishell_error.c                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/03/28 16:52:23 by susumuyagi        #+#    #+#             */
+/*   Updated: 2024/03/28 17:04:42 by susumuyagi       ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+#include "message/message.h"
+#include "minishell.h"
+#include <unistd.h>
+
+void	occurred_redirect_error(t_minishell *minish, t_token *tok)
+{
+	minish->status_code = 1;
+	minish->error_kind = ERR_REDIRECT;
+	ft_printf_fd(STDERR_FILENO, MINISHELL_NAME);
+	write(STDERR_FILENO, tok->str, tok->len);
+	ft_printf_fd(STDERR_FILENO, AMBIGUOUS_REDIRECT);
+}

--- a/test/unit/src/libft/split2.cpp
+++ b/test/unit/src/libft/split2.cpp
@@ -1,0 +1,45 @@
+#include <gtest/gtest.h>
+
+extern "C" {
+#include "libft.h"
+}
+
+TEST(Split2, space_tab) {
+  char** actual = ft_split2(" 	a bb	ccc", " \t");
+
+  std::vector<const char*> expect = {"a", "bb", "ccc", NULL};
+
+  for (size_t i = 0; expect[i]; ++i) {
+    EXPECT_STREQ(expect[i], actual[i]);
+  }
+}
+
+TEST(Split2, empty) {
+  char** actual = ft_split2(" 	  		  ", " 	");
+
+  std::vector<const char*> expect = {NULL};
+
+  for (size_t i = 0; expect[i]; ++i) {
+    EXPECT_STREQ(expect[i], actual[i]);
+  }
+}
+
+TEST(Split2, odd) {
+  char** actual = ft_split2("12345", "24680");
+
+  std::vector<const char*> expect = {"1", "3", "5", NULL};
+
+  for (size_t i = 0; expect[i]; ++i) {
+    EXPECT_STREQ(expect[i], actual[i]);
+  }
+}
+
+TEST(Split2, even) {
+  char** actual = ft_split2("12345", "13579");
+
+  std::vector<const char*> expect = {"2", "4", NULL};
+
+  for (size_t i = 0; expect[i]; ++i) {
+    EXPECT_STREQ(expect[i], actual[i]);
+  }
+}


### PR DESCRIPTION
(マージ先を間違えたので、プルリクを作り直しました。)

# 変数展開した後に空白区切りがある場合に対応しました。
```
minishell $ AA="ls -al"
minishell $ $AA
total 6808
drwxr-xr-x@  17 susumuyagi  staff      544  3 29 13:46 .
drwxr-xr-x   12 susumuyagi  staff      384  3 27 14:07 ..
-rw-r--r--@   1 susumuyagi  staff     6148  3 13 11:52 .DS_Store
drwxr-xr-x@  16 susumuyagi  staff      512  3 29 13:47 .git
```

- （ダブル）クォーテーションで囲まれていない場合はトリムする
```
minishell $ AA="   ls "
minishell $ $AA # lsとして解釈
# (ダブル)クォーテーションで囲まれている場合
minishell $ "$AA"
minishell:    ls : command not found

```

- 構文解析はしない（bashと同じ）
```
minishell $ AA="ls | cat"
minishell $ $AA
ls: cat: No such file or directory
ls: |: No such file or directory

bash-3.2$ AA="ls | cat"
bash-3.2$ $AA
ls: cat: No such file or directory
ls: |: No such file or directory
```

- リダイレクトでスペースがある場合はエラー
```
minishell $ AA="file.txt file2.txt"
minishell $ > $AA
minishell: $AA: ambiguous redirect

bash-3.2$ AA="file.txt file2.txt"
bash-3.2$ > $AA
bash: $AA: ambiguous redirect
```

- ただし、クォーテーションで囲まれている場合は一つの文字列として、ファイル名にする
```
minishell $ AA="file.txt file2.txt"
minishell $ ls > "$AA"
minishell $ ls "file.txt file2.txt"
file.txt file2.txt
```

# minishell_error.c
minishell_error.cというファイルを作りましたが、
mallocなどのエラーの処理をここに書くつもりです。

fix #49