### PR TITLE
tokenizeに失敗した時の終了コードを設定

### DIFF
--- a/include/message/message.h
+++ b/include/message/message.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   message.h                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
+/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/19 16:45:14 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/03/30 11:16:01 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/03/31 11:29:04 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,7 +34,6 @@
 # define PROMPT "minishell $ "
 # define ERROR_MAX_HEREDOC "minishell: maximum here-document count exceeded"
 # define HEREDOC_PROMPT "> "
-# define CANNOT_TOKENIZE "Error: Cannot tokenize\n"
 # define AMBIGUOUS_REDIRECT ": ambiguous redirect\n"
 
 // --- minishell ---

--- a/include/utils/minishell_error.h
+++ b/include/utils/minishell_error.h
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/28 16:53:52 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/31 12:11:23 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/31 15:51:41 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,7 +16,7 @@
 # include "minishell.h"
 
 void	occurred_redirect_error(t_minishell *minish, t_token *tok);
-void	occurred_syntax_error(t_minishell *minish);
+void	occurred_syntax_error(t_minishell *minish, const char *str, size_t len);
 void	*occurred_malloc_error_return_null(t_minishell *minish);
 void	occurred_resource_error(t_minishell *minish, char *resource);
 

--- a/src/parser/lexer.c
+++ b/src/parser/lexer.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 17:20:20 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/31 11:26:59 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/31 16:01:09 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -134,7 +134,18 @@ void	free_tokens(t_token *cur)
 
 static int	error_at(t_minishell *minish, t_token *head, char *p)
 {
-	occurred_syntax_error(minish, p, 1);
+	char	*space;
+	char	*tab;
+	size_t	len;
+
+	tab = ft_strchr(p, '\t');
+	space = ft_strchr(p, ' ');
+	len = ft_strlen(p);
+	if (tab - p > 0 && (space == 0 || tab < space))
+		len = tab - p;
+	if (space - p > 0 && (tab == 0 || space < tab))
+		len = space - p;
+	occurred_syntax_error(minish, p, len);
 	free_tokens(head->next);
 	return (EXIT_FAILURE);
 }

--- a/src/parser/lexer.c
+++ b/src/parser/lexer.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   lexer.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
+/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 17:20:20 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/19 17:17:43 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/03/31 11:26:59 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,7 @@
 #include "message/message.h"
 #include "minishell.h"
 #include "parser/token.h"
+#include "utils/minishell_error.h"
 #include <stdbool.h>
 #include <stdlib.h>
 
@@ -131,9 +132,9 @@ void	free_tokens(t_token *cur)
 	}
 }
 
-static int	error_at(t_token *head)
+static int	error_at(t_minishell *minish, t_token *head, char *p)
 {
-	ft_printf_fd(STDERR_FILENO, CANNOT_TOKENIZE);
+	occurred_syntax_error(minish, p, 1);
 	free_tokens(head->next);
 	return (EXIT_FAILURE);
 }
@@ -174,7 +175,7 @@ int	tokenize(t_minishell *minish)
 			p += word_len;
 			continue ;
 		}
-		return (error_at(&head));
+		return (error_at(minish, &head, p));
 	}
 	new_token(TK_EOF, cur, p, 0);
 	minish->token = head.next;

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 17:37:32 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/29 22:30:30 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/31 11:26:30 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -172,7 +172,8 @@ static bool	expect_word(t_minishell *minish)
 	{
 		return (true);
 	}
-	occurred_syntax_error(minish);
+	occurred_syntax_error(minish, minish->cur_token->str,
+		minish->cur_token->len);
 	return (false);
 }
 
@@ -292,7 +293,8 @@ int	parse(t_minishell *minish)
 	cur = &head;
 	if (at_pipe(minish->cur_token))
 	{
-		occurred_syntax_error(minish);
+		occurred_syntax_error(minish, minish->cur_token->str,
+			minish->cur_token->len);
 	}
 	while (!at_eof(minish->cur_token) && NO_ERROR(minish))
 	{
@@ -302,7 +304,8 @@ int	parse(t_minishell *minish)
 		if (at_pipe(minish->cur_token) && (at_pipe(minish->cur_token->next)
 				|| at_eof(minish->cur_token->next)))
 		{
-			occurred_syntax_error(minish);
+			occurred_syntax_error(minish, minish->cur_token->str,
+				minish->cur_token->len);
 			break ;
 		}
 		consume(minish, "|");

--- a/src/utils/minishell_error.c
+++ b/src/utils/minishell_error.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/28 16:52:23 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/31 12:11:29 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/31 15:52:25 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,13 +27,13 @@ void	occurred_redirect_error(t_minishell *minish, t_token *tok)
 	ft_printf_fd(STDERR_FILENO, AMBIGUOUS_REDIRECT);
 }
 
-void	occurred_syntax_error(t_minishell *minish)
+void	occurred_syntax_error(t_minishell *minish, const char *str, size_t len)
 {
 	minish->status_code = 258;
 	minish->error_kind = ERR_SYNTAX;
 	ft_printf_fd(STDERR_FILENO, SYNTAX_ERROR);
 	write(STDERR_FILENO, "`", 1);
-	write(STDERR_FILENO, minish->cur_token->str, minish->cur_token->len);
+	write(STDERR_FILENO, str, len);
 	write(STDERR_FILENO, "'\n", 2);
 }
 


### PR DESCRIPTION
tokenizeに失敗した時、syntaxエラーとして扱い、終了コードを設定しました。


```
minishell $ echo "
minishell: syntax error near unexpected token `"'
minishell $ echo $?
258

minishell $ echo "hello
minishell: syntax error near unexpected token `"'
minishell $ echo $?
258
```

fix #89