### PR TITLE
pipe,forkのエラー処理追加

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/14 16:21:32 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/03/28 16:53:47 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/31 12:03:45 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,6 +32,7 @@ typedef enum
 	ERR_SYNTAX,
 	ERR_MALLOC,
 	ERR_REDIRECT,
+	ERR_RESOURCE,
 	INTERRUPT,
 }								e_error_kind;
 

--- a/include/utils/minishell_error.h
+++ b/include/utils/minishell_error.h
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/28 16:53:52 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/29 16:25:48 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/31 12:11:23 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,5 +18,6 @@
 void	occurred_redirect_error(t_minishell *minish, t_token *tok);
 void	occurred_syntax_error(t_minishell *minish);
 void	*occurred_malloc_error_return_null(t_minishell *minish);
+void	occurred_resource_error(t_minishell *minish, char *resource);
 
 #endif

--- a/src/exec/pipe.c
+++ b/src/exec/pipe.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/12 12:06:41 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/28 14:32:59 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/31 12:11:44 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,6 +15,7 @@
 #include "exec/redirect.h"
 #include "message/message.h"
 #include "minishell.h"
+#include "utils/minishell_error.h"
 #include "variable/env.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -88,9 +89,7 @@ void	exec_pipe(t_minishell *minish)
 		{
 			if (pipe(fds) < 0)
 			{
-				perror("pipe");
-				// TODO エラー処理
-				exit(EXIT_FAILURE);
+				return (occurred_resource_error(minish, "pipe"));
 			}
 		}
 		node->in_pipe = IS_IN_PIPE(minish);
@@ -103,9 +102,7 @@ void	exec_pipe(t_minishell *minish)
 			node->pid = fork();
 			if (node->pid < 0)
 			{
-				perror("fork");
-				// TODO エラー処理
-				exit(EXIT_FAILURE);
+				return (occurred_resource_error(minish, "fork"));
 			}
 			if (node->pid > 0)
 			{

--- a/src/exec/process.c
+++ b/src/exec/process.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/12 12:06:41 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/28 14:37:59 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/31 13:40:36 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -108,6 +108,11 @@ void	set_status_code(t_minishell *minish)
 	while (node->next != NULL)
 	{
 		node = node->next;
+	}
+	if (minish->error_kind == ERR_RESOURCE)
+	{
+		minish->status_code = EXIT_FAILURE;
+		return ;
 	}
 	minish->status_code = node->wait_status;
 }

--- a/src/utils/minishell_error.c
+++ b/src/utils/minishell_error.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/28 16:52:23 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/29 16:25:17 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/31 12:11:29 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,6 +15,7 @@
 #include "minishell.h"
 #include "utils/exit_status.h"
 #include <errno.h>
+#include <string.h>
 #include <unistd.h>
 
 void	occurred_redirect_error(t_minishell *minish, t_token *tok)
@@ -42,4 +43,11 @@ void	*occurred_malloc_error_return_null(t_minishell *minish)
 	minish->error_kind = ERR_MALLOC;
 	ft_printf_fd(STDERR_FILENO, MINISHELL_ERROR, "malloc", MALLOC_ERROR);
 	return (NULL);
+}
+
+void	occurred_resource_error(t_minishell *minish, char *resource)
+{
+	minish->status_code = EXIT_FAILURE;
+	minish->error_kind = ERR_RESOURCE;
+	ft_printf_fd(STDERR_FILENO, MINISHELL_ERROR, resource, strerror(errno));
 }


### PR DESCRIPTION
pipe、forkで失敗した時のエラー処理を実装しました。
```
minishell $ ls|ls|ls|ls|ls|ls|ls|ls|ls|ls|ls|ls|ls|・・・いっぱい
minishell: fork: Resource temporarily unavailable
minishell $ echo $?
1
```

fix #90 