### PR TITLE
何も入力しない時、終了コードが不正 #95

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/14 16:21:32 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/03/31 18:30:26 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/03/31 19:04:45 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,7 @@
 # include <stdio.h>
 
 // シグナル用グローバル変数
-volatile sig_atomic_t	g_signal;
+extern volatile sig_atomic_t	g_signal;
 
 typedef enum
 {
@@ -32,41 +32,41 @@ typedef enum
 	ERR_REDIRECT,
 	ERR_RESOURCE,
 	INTERRUPT,
-}						e_error_kind;
+}								e_error_kind;
 
 typedef struct s_minishell
 {
 	// 入力文字列
-	char				*line;
+	char						*line;
 
 	// token構造体
-	t_token				*token;
-	t_token				*cur_token;
+	t_token						*token;
+	t_token						*cur_token;
 
 	// node構造体
-	t_node				*node;
+	t_node						*node;
 
 	// 環境変数構造体
-	t_var				*var;
+	t_var						*var;
 
 	// 返り値
-	int					status_code;
+	int							status_code;
 
-	char				*pwd;
+	char						*pwd;
 
 	// 起動時の引数
-	int					argc;
-	const char			**argv;
+	int							argc;
+	const char					**argv;
 
 	// heredoc
-	t_heredoc			heredoc;
+	t_heredoc					heredoc;
 
-	e_error_kind		error_kind;
-}						t_minishell;
+	e_error_kind				error_kind;
+}								t_minishell;
 
-void					init_minishell(t_minishell *minish);
-void					free_minishell(t_minishell *minish);
-void					die_minishell(t_minishell *minish);
-bool					no_error(t_minishell *minish);
+void							init_minishell(t_minishell *minish);
+void							free_minishell(t_minishell *minish);
+void							die_minishell(t_minishell *minish);
+bool							no_error(t_minishell *minish);
 
 #endif

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
+/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/14 16:21:32 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/03/31 16:31:44 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/31 18:30:26 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,7 @@
 # include <stdio.h>
 
 // シグナル用グローバル変数
-static volatile sig_atomic_t	g_signal;
+volatile sig_atomic_t	g_signal;
 
 typedef enum
 {
@@ -32,41 +32,41 @@ typedef enum
 	ERR_REDIRECT,
 	ERR_RESOURCE,
 	INTERRUPT,
-}								e_error_kind;
+}						e_error_kind;
 
 typedef struct s_minishell
 {
 	// 入力文字列
-	char						*line;
+	char				*line;
 
 	// token構造体
-	t_token						*token;
-	t_token						*cur_token;
+	t_token				*token;
+	t_token				*cur_token;
 
 	// node構造体
-	t_node						*node;
+	t_node				*node;
 
 	// 環境変数構造体
-	t_var						*var;
+	t_var				*var;
 
 	// 返り値
-	int							status_code;
+	int					status_code;
 
-	char						*pwd;
+	char				*pwd;
 
 	// 起動時の引数
-	int							argc;
-	const char					**argv;
+	int					argc;
+	const char			**argv;
 
 	// heredoc
-	t_heredoc					heredoc;
+	t_heredoc			heredoc;
 
-	e_error_kind				error_kind;
-}								t_minishell;
+	e_error_kind		error_kind;
+}						t_minishell;
 
-void							init_minishell(t_minishell *minish);
-void							free_minishell(t_minishell *minish);
-void							die_minishell(t_minishell *minish);
-bool							no_error(t_minishell *minish);
+void					init_minishell(t_minishell *minish);
+void					free_minishell(t_minishell *minish);
+void					die_minishell(t_minishell *minish);
+bool					no_error(t_minishell *minish);
 
 #endif

--- a/include/signal/signal.h
+++ b/include/signal/signal.h
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/22 12:16:18 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/03/31 17:39:37 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/03/31 18:48:34 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,7 @@
 # define CTRL_C 1
 
 void	ctrl_c_handler(int sig);
-void	ctrl_c_blank_line_handler(t_minishell *minish, int sig);
+void	ctrl_c_blank_line_handler(t_minishell *minish);
 void	ctrl_d_clean_handler(t_minishell *minish);
 
 #endif

--- a/include/signal/signal.h
+++ b/include/signal/signal.h
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/22 12:16:18 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/03/19 17:21:42 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/03/31 17:39:37 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,7 @@
 # define CTRL_C 1
 
 void	ctrl_c_handler(int sig);
-void	ctrl_c_clean_handler(t_minishell *minish);
+void	ctrl_c_blank_line_handler(t_minishell *minish, int sig);
 void	ctrl_d_clean_handler(t_minishell *minish);
 
 #endif

--- a/src/exec/process.c
+++ b/src/exec/process.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   process.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
+/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/12 12:06:41 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/31 13:40:36 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/31 18:32:05 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -88,6 +88,7 @@ void	wait_prosesses(t_minishell *minish)
 					WTERMSIG(node->wait_status));
 			}
 			node->wait_status |= 128;
+			g_signal = 0;
 		}
 		else if (WIFSTOPPED(node->wait_status))
 		{

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 13:22:07 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/31 18:38:45 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/03/31 19:09:05 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,8 @@
 // 	system("leaks -q minishell");
 // }
 
+volatile sig_atomic_t	g_signal = 0;
+
 int	event(void)
 {
 	return (0);
@@ -34,7 +36,6 @@ int	main(int argc, const char **argv, const char **envp)
 	init_minishell(&minish);
 	minish.argc = argc;
 	minish.argv = argv;
-	g_signal = 0;
 	signal(SIGINT, ctrl_c_handler);
 	rl_event_hook = event;
 	if (argc > 1)

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 13:22:07 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/21 19:18:02 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/03/31 18:38:45 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,9 +34,8 @@ int	main(int argc, const char **argv, const char **envp)
 	init_minishell(&minish);
 	minish.argc = argc;
 	minish.argv = argv;
+	g_signal = 0;
 	signal(SIGINT, ctrl_c_handler);
-	// hookを設定することでrl_doneが効くようになったのでreadlineから抜けることができる
-	// hookはwebに上がっているminishellでも使っているので使っても良いかも使える理由を探し中
 	rl_event_hook = event;
 	if (argc > 1)
 	{

--- a/src/parser/prompt.c
+++ b/src/parser/prompt.c
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 14:13:54 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/31 18:33:46 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/03/31 18:47:59 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,7 +31,7 @@ void	prompt(t_minishell *minish)
 	if (minish->line == NULL)
 		ctrl_d_clean_handler(minish);
 	else if (ft_strcmp(minish->line, "") == 0)
-		ctrl_c_blank_line_handler(minish, g_signal);
+		ctrl_c_blank_line_handler(minish);
 	if (ft_strlen(minish->line) == 0)
 		return (free_minishell(minish));
 	add_history(minish->line);

--- a/src/parser/prompt.c
+++ b/src/parser/prompt.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   prompt.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
+/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 14:13:54 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/26 21:28:56 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/03/31 18:33:46 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,7 +31,7 @@ void	prompt(t_minishell *minish)
 	if (minish->line == NULL)
 		ctrl_d_clean_handler(minish);
 	else if (ft_strcmp(minish->line, "") == 0)
-		ctrl_c_clean_handler(minish);
+		ctrl_c_blank_line_handler(minish, g_signal);
 	if (ft_strlen(minish->line) == 0)
 		return (free_minishell(minish));
 	add_history(minish->line);

--- a/src/signal/signal.c
+++ b/src/signal/signal.c
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/22 12:15:51 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/03/31 18:34:07 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/03/31 18:48:18 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,9 +34,9 @@ void	ctrl_c_handler(int sig)
 	rl_done = 1;
 }
 
-void	ctrl_c_blank_line_handler(t_minishell *minish, int sig)
+void	ctrl_c_blank_line_handler(t_minishell *minish)
 {
-	if (sig == CTRL_C)
+	if (g_signal == CTRL_C)
 		minish->status_code = EXIT_FAILURE;
 	g_signal = 0;
 }

--- a/src/signal/signal.c
+++ b/src/signal/signal.c
@@ -6,13 +6,14 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/22 12:15:51 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/03/21 19:12:51 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/03/31 18:34:07 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 #include "minishell.h"
 #include "signal/signal.h"
+#include "utils/exit_status.h"
 #include <stdlib.h>
 
 void	node_kill(t_node *node)
@@ -28,26 +29,16 @@ void	node_kill(t_node *node)
 void	ctrl_c_handler(int sig)
 {
 	(void)sig;
-	// なぜかg_signalの値が更新されない...
 	g_signal = CTRL_C;
 	rl_replace_line("", 0);
 	rl_done = 1;
 }
 
-void	ctrl_c_clean_handler(t_minishell *minish)
+void	ctrl_c_blank_line_handler(t_minishell *minish, int sig)
 {
-	t_node	*node;
-
-	node = minish->node;
+	if (sig == CTRL_C)
+		minish->status_code = EXIT_FAILURE;
 	g_signal = 0;
-	if (node == NULL)
-		minish->status_code = 1;
-	else
-	{
-		node_kill(node);
-		minish->status_code = 130;
-		free_minishell(minish);
-	}
 }
 
 void	ctrl_d_clean_handler(t_minishell *minish)


### PR DESCRIPTION
- グローバル変数のstaticを削除
- コマンド実行中にctrl_c押した後、グローバル変数を初期化
- readline中のctrl_cのハンドラーではfreeしないように修正

コマンド実行した後に、ctrl_cを再度実行した場合は終了ステータスを1に戻す
```
minishell $ sleep 100
^CInterrupt: 2
minishell $  　　　　←ctrl_c実行
minishell $ echo $?
1
```

fix #95