### PR TITLE
find_pathとlexerにmallocエラー処理を追加しました。

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ UNAME := $(shell uname)
 LIBFT_DIR := ./libft
 LIBFT := $(LIBFT_DIR)/libft.a
 # readline
+READLINE_TAR_GZ := readline-8.2.tar.gz
 READLINE_DIR := ./readline-8.2
 READLINE := $(READLINE_DIR)/libreadline.a
 
@@ -31,6 +32,7 @@ SRCS := src/main.c src/minishell.c \
 	src/utils/utils.c src/utils/minishell_error.c
 OBJS := $(SRCS:.c=.o)
 
+.PHONY: all
 all: $(NAME)
 
 $(NAME): $(READLINE) $(OBJS) $(LIBFT)
@@ -42,36 +44,42 @@ $(NAME): $(READLINE) $(OBJS) $(LIBFT)
 $(LIBFT):
 	$(MAKE) -j4 -C $(LIBFT_DIR)
 
-$(READLINE):
+$(READLINE_TAR_GZ):
 	curl -O ftp://ftp.gnu.org/gnu/readline/readline-8.2.tar.gz
+
+$(READLINE): $(READLINE_TAR_GZ)
 	tar xvzf readline-8.2.tar.gz
 	cd $(READLINE_DIR) && ./configure && $(MAKE) -j4
 
 
-.PHONY: clean fclean re
-
+.PHONY: clean
 clean:
 	$(RM) $(OBJS)
 	$(MAKE) -C $(LIBFT_DIR) clean
 
+.PHONY: fclean
 fclean: clean
 	$(RM) $(NAME)
 	$(MAKE) -C $(LIBFT_DIR) fclean
 	$(RM) -r $(READLINE_DIR)
-	$(RM) readline-8.2.tar.gz
 
+.PHONY: re
 re: fclean all
 
 # test
-.PHONY: unit_test e2e_test e2e_clean
+.PHONY: test
+test: unit_test e2e_test
 
+.PHONY: unit_test
 unit_test: $(READLINE) $(LIBFT)
 	cd test/unit && \
 	cmake -S . -B build && cmake --build build &&  cd build && ctest
 
+.PHONY: e2e_test
 e2e_test: $(NAME) $(e2e_clean)
 	cd test/e2e && ./run_e2e.sh
 
+.PHONY: e2e_clean
 e2e_clean:
 	$(RM) test/e2e/out/*.out
 	$(RM) test/e2e/out/*.diff

--- a/include/exec/find_path.h
+++ b/include/exec/find_path.h
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 14:19:35 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/02/21 13:36:34 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/01 14:45:08 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,6 +15,6 @@
 
 # include "minishell.h"
 
-void	set_cmd_path(t_minishell *minish);
+int	set_cmd_path(t_minishell *minish);
 
 #endif

--- a/src/exec/exec.c
+++ b/src/exec/exec.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/19 16:23:27 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/12 17:01:33 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/01 15:27:58 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,7 +38,8 @@ void	exec(t_minishell *minish)
 
 	if (minish->node == NULL)
 		return ;
-	set_cmd_path(minish);
+	if (set_cmd_path(minish))
+		return ;
 	save_orig_io(orig_io);
 	exec_pipe(minish);
 	wait_prosesses(minish);

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 13:22:07 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/31 16:31:29 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/01 17:23:24 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,6 +45,7 @@ void	free_minishell(t_minishell *minish)
 	minish->node = NULL;
 	free_heredoc(&minish->heredoc);
 	init_heredoc(&minish->heredoc);
+	minish->error_kind = ERR_NONE;
 }
 
 void	die_minishell(t_minishell *minish)

--- a/src/parser/lexer.c
+++ b/src/parser/lexer.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 17:20:20 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/31 16:01:09 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/01 16:12:12 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,13 +39,17 @@
 ////////////////////////////////////////////////////////////////
 
 // generate new token and connect to the current token
-static t_token	*new_token(e_token_kind kind, t_token *cur, char *str,
-		size_t len)
+static t_token	*new_token(t_minishell *minish, e_token_kind kind, t_token *cur,
+		char *str, size_t len)
 {
 	t_token	*tok;
 
 	tok = (t_token *)malloc(sizeof(t_token));
-	// TODO エラー処理
+	if (!tok)
+	{
+		occurred_malloc_error_return_null(minish);
+		return (NULL);
+	}
 	tok->kind = kind;
 	tok->str = str;
 	tok->len = len;
@@ -160,7 +164,7 @@ int	tokenize(t_minishell *minish)
 	head.next = NULL;
 	cur = &head;
 	p = minish->line;
-	while (*p)
+	while (*p && no_error(minish))
 	{
 		if (ft_isspace(*p))
 		{
@@ -169,30 +173,31 @@ int	tokenize(t_minishell *minish)
 		}
 		if (is_starts_with("<<", p, 2) || is_starts_with(">>", p, 2))
 		{
-			cur = new_token(TK_RESERVED, cur, p, 2);
+			cur = new_token(minish, TK_RESERVED, cur, p, 2);
 			p += 2;
 			continue ;
 		}
 		if (is_reserved(*p))
 		{
-			cur = new_token(TK_RESERVED, cur, p, 1);
+			cur = new_token(minish, TK_RESERVED, cur, p, 1);
 			p++;
 			continue ;
 		}
 		word_len = count_word_len(p);
 		if (word_len > 0)
 		{
-			cur = new_token(TK_WORD, cur, p, word_len);
+			cur = new_token(minish, TK_WORD, cur, p, word_len);
 			p += word_len;
 			continue ;
 		}
 		return (error_at(minish, &head, p));
 	}
-	new_token(TK_EOF, cur, p, 0);
+	if (no_error(minish))
+		new_token(minish, TK_EOF, cur, p, 0);
 	minish->token = head.next;
 	///////////////////////////////////////
 	// TODO 後で消す
 	// print_tokens(minish->token);
 	///////////////////////////////////////
-	return (EXIT_SUCCESS);
+	return (!no_error(minish));
 }

--- a/test/bin/ls
+++ b/test/bin/ls
@@ -1,0 +1,3 @@
+#!/bin/bash
+# no permission
+ls

--- a/test/e2e/case/find_path.in
+++ b/test/e2e/case/find_path.in
@@ -1,0 +1,9 @@
+unset PATH
+ls
+echo $?
+PATH=../bin
+ls
+echo $?
+PATH=../bin:/bin:../bin
+ls
+echo $?

--- a/test/unit/src/parser/lexer.cpp
+++ b/test/unit/src/parser/lexer.cpp
@@ -9,6 +9,7 @@ extern "C" {
 // Demonstrate some basic assertions.
 TEST(Lexer, words) {
   t_minishell minish;
+  init_minishell(&minish);
   minish.line = ft_strdup("ls -al file1.txt file2.txt");
 
   tokenize(&minish);
@@ -35,6 +36,7 @@ TEST(Lexer, words) {
 
 TEST(Lexer, pipe) {
   t_minishell minish;
+  init_minishell(&minish);
   minish.line = ft_strdup(
       "> in1 < out1 ls -al|cat file1 file2>out1>out2>>att1<in1<in2 file3|ps "
       "-aux");
@@ -66,6 +68,7 @@ TEST(Lexer, pipe) {
 
 TEST(Lexer, quote_and_d_quote) {
   t_minishell minish;
+  init_minishell(&minish);
   minish.line = ft_strdup("echo \"ls | cat\"'$PWD'\" > \"' << '");
 
   tokenize(&minish);
@@ -92,6 +95,7 @@ TEST(Lexer, quote_and_d_quote) {
 
 TEST(Lexer, nest_quote) {
   t_minishell minish;
+  init_minishell(&minish);
   minish.line = ft_strdup("\" ' ' \" '\"' \"'\"");
 
   tokenize(&minish);
@@ -118,6 +122,7 @@ TEST(Lexer, nest_quote) {
 
 TEST(Lexer, only_space) {
   t_minishell minish;
+  init_minishell(&minish);
   minish.line = ft_strdup("     \t   ");
 
   tokenize(&minish);
@@ -140,4 +145,24 @@ TEST(Lexer, only_space) {
     EXPECT_STREQ(expected[i], actual[i]);
     EXPECT_EQ(expected_kind[i], actual_kind[i]);
   }
+}
+
+TEST(Lexer, donot_close_quote) {
+  t_minishell minish;
+  init_minishell(&minish);
+  minish.line = ft_strdup("echo '");
+
+  tokenize(&minish);
+
+  ASSERT_EQ(ERR_SYNTAX, minish.error_kind);
+}
+
+TEST(Lexer, donot_close_d_quote) {
+  t_minishell minish;
+  init_minishell(&minish);
+  minish.line = ft_strdup("echo \"aaa 'bbb' ccc");
+
+  tokenize(&minish);
+
+  ASSERT_EQ(ERR_SYNTAX, minish.error_kind);
 }


### PR DESCRIPTION
find_pathとlexerにmallocエラー処理を追加しました。

Makefileを少し修正しました
-  readlineのダウンロードとビルドのターゲットを分けました。
make reするたびに一々readlineをダウンロードしてくるのがめんどくさかったので、
readlineのtarファイルを一度ダウンロードしたら、削除しないようにしました。

-  単体テストとE2Eテストを同時に実行するターゲットを追加しました。
```
make test
```
