### PR TITLE
メモリリーク修正

### DIFF
--- a/include/exec/process.h
+++ b/include/exec/process.h
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 14:19:35 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/28 14:39:02 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/02 17:00:38 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,7 +16,7 @@
 # include "minishell.h"
 # include "parser/node.h"
 
-void	exec_cmd(t_node *node, char **envp, char *path);
+void	exec_cmd(t_minishell *minish, t_node *node);
 t_node	*parent_process(t_node *node, int prev_fds[]);
 void	wait_prosesses(t_minishell *minish);
 void	set_status_code(t_minishell *minish);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
+/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/14 16:21:32 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/03/31 19:04:45 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/04/02 16:45:56 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -66,7 +66,8 @@ typedef struct s_minishell
 
 void							init_minishell(t_minishell *minish);
 void							free_minishell(t_minishell *minish);
-void							die_minishell(t_minishell *minish);
+void							die_minishell_and_exit(t_minishell *minish,
+									int exit_code);
 bool							no_error(t_minishell *minish);
 
 #endif

--- a/src/builtin/builtin_exit.c
+++ b/src/builtin/builtin_exit.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   builtin_exit.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
+/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/23 19:23:01 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/02 19:09:32 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/04/04 15:11:05 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -112,12 +112,10 @@ int	builtin_exit(t_minishell *minish, t_node *node)
 			NUM_ARG_REQUIRED);
 		node->wait_status = EXIT_OUT_OF_RANGE_STATUS;
 		minish->status_code = EXIT_OUT_OF_RANGE_STATUS;
-		die_minishell(minish);
-		exit(minish->status_code);
+		die_minishell_and_exit(minish, minish->status_code);
 	}
 	if (!node->in_pipe)
 		ft_printf_fd(STDOUT_FILENO, "exit\n");
-	die_minishell(minish);
-	exit(minish->status_code);
+	die_minishell_and_exit(minish, minish->status_code);
 	return (0);
 }

--- a/src/exec/pipe.c
+++ b/src/exec/pipe.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/12 12:06:41 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/31 16:26:54 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/02 17:01:07 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,32 +52,11 @@ static void	connect_io(t_minishell *minish, t_node *node, int prev_fds[],
 	}
 }
 
-// static void	pipe_and_fork(t_node *node, int fds[])
-// {
-// 	if (node->next != NULL)
-// 	{
-// 		if (pipe(fds) < 0)
-// 		{
-// 			perror("pipe");
-// 			// TODO エラー処理
-// 			exit(EXIT_FAILURE);
-// 		}
-// 	}
-// 	node->pid = fork();
-// 	if (node->pid < 0)
-// 	{
-// 		perror("fork");
-// 		// TODO エラー処理
-// 		exit(EXIT_FAILURE);
-// 	}
-// }
-
 void	exec_pipe(t_minishell *minish)
 {
 	int		prev_fds[2];
 	int		fds[2];
 	t_node	*node;
-	char	**envp;
 
 	init_fds(prev_fds, fds);
 	node = minish->node;
@@ -115,21 +94,20 @@ void	exec_pipe(t_minishell *minish)
 		{
 			if (is_builtin(node) && !node->in_pipe)
 				return ;
-			exit(EXIT_FAILURE);
+			die_minishell_and_exit(minish, EXIT_FAILURE);
 		}
 		if (is_builtin(node))
 		{
 			lookup_builtin_func(node)(minish, node);
 			if (node->in_pipe)
 			{
-				exit(node->wait_status);
+				die_minishell_and_exit(minish, node->wait_status);
 			}
 			node = node->next;
 		}
 		else
 		{
-			envp = get_envp(minish);
-			exec_cmd(node, envp, get_var(minish, "PATH"));
+			exec_cmd(minish, node);
 		}
 	}
 }

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 13:22:07 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/01 17:23:24 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/02 16:45:30 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,10 +48,11 @@ void	free_minishell(t_minishell *minish)
 	minish->error_kind = ERR_NONE;
 }
 
-void	die_minishell(t_minishell *minish)
+void	die_minishell_and_exit(t_minishell *minish, int exit_code)
 {
 	free_minishell(minish);
 	free_var(minish);
+	exit(exit_code);
 }
 
 bool	no_error(t_minishell *minish)

--- a/src/parser/heredoc.c
+++ b/src/parser/heredoc.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/15 15:43:15 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/29 22:39:48 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/02 16:46:16 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,8 +56,7 @@ int	set_heredoc_delimiter(t_minishell *minish, t_token *tok)
 	if (minish->heredoc.num >= MAX_HEREDOC)
 	{
 		ft_printf_fd(STDERR_FILENO, ERROR_MAX_HEREDOC);
-		die_minishell(minish);
-		exit(EXIT_MAX_HEREDOC);
+		die_minishell_and_exit(minish, EXIT_MAX_HEREDOC);
 	}
 	idx = minish->heredoc.num;
 	minish->heredoc.num++;

--- a/src/parser/node.c
+++ b/src/parser/node.c
@@ -6,40 +6,13 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/02 17:09:54 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/27 13:13:10 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/01 17:57:50 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "parser/node.h"
 #include "utils/utils.h"
 #include <stdlib.h>
-
-static void	free_redirect(t_node *node)
-{
-	t_node	*tmp;
-
-	while (node)
-	{
-		tmp = node->next;
-		free_array((void **)node->argv);
-		free(node->path);
-		free(node);
-		node = tmp;
-	}
-}
-
-static void	free_declare(t_node *node)
-{
-	t_node	*tmp;
-
-	while (node)
-	{
-		tmp = node->redirect;
-		free_array((void **)node->argv);
-		free(node);
-		node = tmp;
-	}
-}
 
 void	free_nodes(t_node *node)
 {
@@ -48,8 +21,8 @@ void	free_nodes(t_node *node)
 	while (node)
 	{
 		tmp = node->next;
-		free_redirect(node->redirect);
-		free_declare(node->declare);
+		free_nodes(node->redirect);
+		free_nodes(node->declare);
 		free_array((void **)node->argv);
 		free(node->path);
 		free(node);

--- a/src/signal/signal.c
+++ b/src/signal/signal.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   signal.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
+/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/22 12:15:51 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/03/31 18:48:18 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/04/02 16:46:21 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,6 +47,5 @@ void	ctrl_d_clean_handler(t_minishell *minish)
 
 	node = minish->node;
 	node_kill(node);
-	die_minishell(minish);
-	exit(minish->status_code);
+	die_minishell_and_exit(minish, minish->status_code);
 }


### PR DESCRIPTION
macをアップデートしたところ、なぜか僕の環境でleaks -q minishellが動かなくなってしまい、
子プロセスのリークがなくなっているのか確認できなくなってしまいました。
お手数ですが子プロセスのリークが治っているか確認して頂けませぬんか。
すみません。
（別の方法で親プロセスのリークは確認できるのですが）

## 複数シェル変数宣言時にメモリリーク
fix #104 
free_declare(t_node *node)のロジックを修正。
やることはfree_nodesと同じなので、共通化しました。


## 存在しないコマンド実行時に子プロセスでメモリリーク
#105 は解消できず一旦保留
exec_cmd内でexitする時にメモリを開放するようにしました。


（同じメモリリークなので一緒にやってしまいましたが、修正内容が全然異なるので、やっぱり2つに分けるべきでした。。。）

