### PR TITLE
値が無い場合のexport結果がbashと異なる #123対応

### DIFF
--- a/include/message/message.h
+++ b/include/message/message.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   message.h                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
+/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/19 16:45:14 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/03/31 11:29:04 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/10 15:29:32 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,7 @@
 # define B_TOO_MANY_ARGS "too many arguments"
 # define NUM_ARG_REQUIRED "numeric argument required"
 # define DECLARE "declare -x %s=\"%s\"\n"
+# define DECLARE_VAL_NULL "declare -x %s\n"
 # define IDENTIFIER_ERROR "minishell: %s: `%s': not a valid identifier\n"
 
 // --- exec ---

--- a/include/variable/env_util.h
+++ b/include/variable/env_util.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   env_util.h                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
+/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/14 16:21:32 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/04/10 15:28:39 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/10 18:12:39 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,12 +19,13 @@
 int		ft_strchr_int(const char *s, int c);
 char	*get_key_from_env(const char *envp);
 char	*get_val_from_env(const char *envp);
-char	*join_three_word(char *s1, char *s2, char *s3);
 int		env_el_counter(t_minishell *minish);
+char	*get_key_from_minish(t_minishell *minish, t_var *current);
 void	set_err_kind(t_minishell *minish, t_error_kind kind);
 void	set_err_kind_free(t_minishell *minish, t_error_kind kind, char **s);
 bool	swap_if_greater(char **key_list, size_t i, size_t *cmp_len,
 			bool *sort_flag);
-char	*get_key_from_minish(t_minishell *minish, t_var *current);
+char	*join_three_word(char *s1, char *s2, char *s3);
+char	*join_key_val(t_var *current);
 
 #endif

--- a/src/builtin/builtin_export.c
+++ b/src/builtin/builtin_export.c
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/23 19:23:01 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/07 19:33:03 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/04/10 15:29:57 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,8 +31,13 @@ static void	print_env(t_minishell *minish)
 	i = 0;
 	while (key_list[i] != NULL)
 	{
-		ft_printf_fd(STDOUT_FILENO, DECLARE, key_list[i], get_var(minish,
-				key_list[i]));
+		if (get_var(minish, key_list[i]) == NULL)
+			ft_printf_fd(STDOUT_FILENO, DECLARE_VAL_NULL, key_list[i]);
+		else
+		{
+			ft_printf_fd(STDOUT_FILENO, DECLARE, key_list[i], get_var(minish,
+					key_list[i]));
+		}
 		i++;
 	}
 	free_array((void **)key_list);
@@ -82,6 +87,8 @@ static void	set_env(t_minishell *minish, t_node *node)
 		{
 			if (has_key(minish, key_value[0]))
 				set_type(minish, key_value[0], VAR_ENV);
+			else
+				add_or_update_var(minish, key_value[0], key_value[1], VAR_ENV);
 		}
 		else
 			print_identifier_err(node, i);

--- a/src/variable/env.c
+++ b/src/variable/env.c
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/20 16:23:06 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/09 15:34:39 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/04/10 18:09:41 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -60,7 +60,7 @@ char	**get_envp(t_minishell *minish)
 	{
 		if (current->type == VAR_ENV)
 		{
-			envp[i] = join_three_word(current->key, "=", current->val);
+			envp[i] = join_key_val(current);
 			if (envp[i] == NULL)
 				return (set_err_kind_free(minish, ERR_MALLOC, envp), NULL);
 		}

--- a/src/variable/env_util1.c
+++ b/src/variable/env_util1.c
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/08 10:09:48 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/04/09 15:20:01 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/04/10 18:12:17 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,24 +56,6 @@ char	*get_val_from_env(const char *envp)
 	return (val);
 }
 
-char	*join_three_word(char *s1, char *s2, char *s3)
-{
-	char	*s1_s2;
-	char	*result;
-
-	s1_s2 = ft_strjoin(s1, s2);
-	if (s1_s2 == NULL)
-		return (NULL);
-	result = ft_strjoin(s1_s2, s3);
-	if (result == NULL)
-	{
-		free(s1_s2);
-		return (NULL);
-	}
-	free(s1_s2);
-	return (result);
-}
-
 int	env_el_counter(t_minishell *minish)
 {
 	size_t	env_elements;
@@ -87,4 +69,22 @@ int	env_el_counter(t_minishell *minish)
 		current = current->next;
 	}
 	return (env_elements);
+}
+
+char	*get_key_from_minish(t_minishell *minish, t_var *current)
+{
+	char	*key;
+
+	if (current->type == VAR_ENV)
+	{
+		key = ft_strdup(current->key);
+		if (key == NULL)
+		{
+			minish->error_kind = ERR_MALLOC;
+			return (NULL);
+		}
+	}
+	else
+		key = NULL;
+	return (key);
 }

--- a/src/variable/env_util2.c
+++ b/src/variable/env_util2.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   env_util2.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
+/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/08 11:54:11 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/04/10 15:28:46 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/10 18:11:51 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,20 +41,31 @@ bool	swap_if_greater(char **key_list, size_t i, size_t *cmp_len,
 	return (true);
 }
 
-char	*get_key_from_minish(t_minishell *minish, t_var *current)
+char	*join_three_word(char *s1, char *s2, char *s3)
 {
-	char	*key;
+	char	*s1_s2;
+	char	*result;
 
-	if (current->type == VAR_ENV)
+	s1_s2 = ft_strjoin(s1, s2);
+	if (s1_s2 == NULL)
+		return (NULL);
+	result = ft_strjoin(s1_s2, s3);
+	if (result == NULL)
 	{
-		key = ft_strdup(current->key);
-		if (key == NULL)
-		{
-			minish->error_kind = ERR_MALLOC;
-			return (NULL);
-		}
+		free(s1_s2);
+		return (NULL);
 	}
+	free(s1_s2);
+	return (result);
+}
+
+char	*join_key_val(t_var *current)
+{
+	char	*key_val;
+
+	if (current->val == NULL)
+		key_val = ft_strjoin(current->key, "=");
 	else
-		key = NULL;
-	return (key);
+		key_val = join_three_word(current->key, "=", current->val);
+	return (key_val);
 }

--- a/src/variable/var.c
+++ b/src/variable/var.c
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/20 16:23:06 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/14 15:53:24 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/04/10 15:23:46 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,9 +25,14 @@ static t_var	*create_var(e_var_type type, const char *key, const char *val)
 	new_var->key = ft_strdup(key);
 	if (new_var->key == NULL)
 		return (free(new_var), NULL);
-	new_var->val = ft_strdup(val);
-	if (new_var->val == NULL)
-		return (free(new_var->key), free(new_var), NULL);
+	if (val == NULL)
+		new_var->val = NULL;
+	else
+	{
+		new_var->val = ft_strdup(val);
+		if (new_var->val == NULL)
+			return (free(new_var->key), free(new_var), NULL);
+	}
 	new_var->next = NULL;
 	return (new_var);
 }
@@ -58,6 +63,8 @@ void	add_or_update_var(t_minishell *minish, const char *key, const char *val,
 	{
 		if (ft_strcmp(current->key, key) == 0)
 		{
+			if (val == NULL)
+				return ;
 			free(current->val);
 			current->val = ft_strdup(val);
 			if (current->type == VAR_SHELL)

--- a/test/e2e/case/builtin_export.in
+++ b/test/e2e/case/builtin_export.in
@@ -7,25 +7,51 @@ export | grep -v "declare -x SHLVL=" | grep -v "declare -x _=" | grep -v "declar
 export | grep -v "declare -x SHLVL=" | grep -v "declare -x _=" | grep -v "declare -x OLDPWD"
 echo $?
 export TEST=bb
-echo $?
 env | grep TEST
+export | grep TEST
+echo $?
 export TEST=
 env | grep TEST
+export | grep TEST
+echo $?
 export TEST="abc"
 env | grep TEST
+export | grep TEST
+echo $?
 export TEST1= TEST2=hello
 env | grep TEST1
+export | grep TEST1
+echo $?
 env | grep TEST2
+export | grep TEST2
+echo $?
 export _TEST1=123
 env | grep _TEST1
 export 1_TEST1=123
 env | grep 1_TEST1
 export AA=11 1 BB=22 2
 echo $?
+env | grep AA
+export | grep AA
+env | grep BB
+export | grep BB
 export ?a=_1 ?b=2
 echo $?
 export a=_1 ?b=2
 echo $?
 AAA=99
 export AAA
-export XX
+export CCC
+export | grep CCC
+export DDD
+DDD=dkdk
+export | grep DDD
+export EEE
+export EEE=llll
+export | grep EEE
+export FFF
+export FFF
+export | grep FFF
+export GGG=123
+export GGG
+export | grep GGG

--- a/test/unit/src/variable/var.cpp
+++ b/test/unit/src/variable/var.cpp
@@ -12,7 +12,7 @@ TEST(Variable, add)
 {
   t_minishell minish;
   const char *expect[] = {"HOME=/home", "USER=me", "PATH=/usr/bin",
-                          "ENV1=", "ENV2=a=b=c", NULL};
+                          "ENV1=", "ENV3=", "ENV2=a=b=c", NULL};
   char **actual;
 
   init_minishell(&minish);
@@ -20,6 +20,7 @@ TEST(Variable, add)
   add_or_update_var(&minish, "USER", "me", VAR_ENV);
   add_or_update_var(&minish, "PATH", "/usr/bin", VAR_ENV);
   add_or_update_var(&minish, "ENV1", "", VAR_ENV);
+  add_or_update_var(&minish, "ENV3", NULL, VAR_ENV);
   add_or_update_var(&minish, "ENV2", "a=b=c", VAR_ENV);
   actual = get_envp(&minish);
   for (size_t i = 0; expect[i]; ++i)
@@ -43,6 +44,7 @@ TEST(Variable, update)
   set_envp(&minish, envp);
   add_or_update_var(&minish, "ENV1", "update", VAR_ENV);
   add_or_update_var(&minish, "ENV", "add", VAR_ENV);
+  add_or_update_var(&minish, "ENV2", NULL, VAR_ENV);
   actual = get_envp(&minish);
   for (size_t i = 0; expect[i]; ++i)
   {


### PR DESCRIPTION
- var.typeにVAR_EXPORT, VAR_NONEを追加 (VAR_NONEは使わない)
- 値がない場合はVAR_EXPORT
- VAL_EXPORTのkeyが更新される場合は、シェル変数、環境変数問わずVAL_ENVに昇格させる
- テストケース追加
- normは後ほど対応

fix #123 