### PR TITLE
envで値がNULLの環境変数も出力してしまう対応

### DIFF
--- a/include/variable/env_util.h
+++ b/include/variable/env_util.h
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/14 16:21:32 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/04/10 18:12:39 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/04/11 15:56:25 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@
 int		ft_strchr_int(const char *s, int c);
 char	*get_key_from_env(const char *envp);
 char	*get_val_from_env(const char *envp);
-int		env_el_counter(t_minishell *minish);
+int		env_el_counter(t_minishell *minish, bool val_null_flag);
 char	*get_key_from_minish(t_minishell *minish, t_var *current);
 void	set_err_kind(t_minishell *minish, t_error_kind kind);
 void	set_err_kind_free(t_minishell *minish, t_error_kind kind, char **s);

--- a/src/variable/env.c
+++ b/src/variable/env.c
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/20 16:23:06 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/11 13:12:09 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/04/11 15:57:19 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,7 +50,7 @@ char	**get_envp(t_minishell *minish)
 	char	**envp;
 	size_t	i;
 
-	env_elements = env_el_counter(minish);
+	env_elements = env_el_counter(minish, false);
 	envp = (char **)ft_calloc(env_elements + 1, sizeof(char *));
 	if (envp == NULL)
 		return (set_err_kind(minish, ERR_MALLOC), NULL);
@@ -101,7 +101,7 @@ char	**get_key_list(t_minishell *minish)
 	char	**key_list;
 	size_t	i;
 
-	env_elements = env_el_counter(minish);
+	env_elements = env_el_counter(minish, true);
 	key_list = (char **)ft_calloc(env_elements + 1, sizeof(char *));
 	if (key_list == NULL)
 		return (set_err_kind(minish, ERR_MALLOC), NULL);
@@ -109,11 +109,14 @@ char	**get_key_list(t_minishell *minish)
 	i = 0;
 	while (current)
 	{
-		key_list[i] = get_key_from_minish(minish, current);
-		if (minish->error_kind == ERR_MALLOC)
-			return (free_array((void **)key_list), NULL);
+		if (current->type == VAR_ENV)
+		{
+			key_list[i] = get_key_from_minish(minish, current);
+			if (key_list[i] == NULL)
+				return (free_array((void **)key_list), NULL);
+			i++;
+		}
 		current = current->next;
-		i++;
 	}
 	return (key_list);
 }

--- a/src/variable/env.c
+++ b/src/variable/env.c
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/20 16:23:06 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/10 18:09:41 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/04/11 13:12:09 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,16 +58,14 @@ char	**get_envp(t_minishell *minish)
 	i = 0;
 	while (current)
 	{
-		if (current->type == VAR_ENV)
+		if (current->type == VAR_ENV && current->val != NULL)
 		{
 			envp[i] = join_key_val(current);
 			if (envp[i] == NULL)
 				return (set_err_kind_free(minish, ERR_MALLOC, envp), NULL);
+			i++;
 		}
-		else
-			envp[i] = NULL;
 		current = current->next;
-		i++;
 	}
 	return (envp);
 }

--- a/src/variable/env_util1.c
+++ b/src/variable/env_util1.c
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/08 10:09:48 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/04/10 18:12:17 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/04/11 15:55:24 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,7 +56,7 @@ char	*get_val_from_env(const char *envp)
 	return (val);
 }
 
-int	env_el_counter(t_minishell *minish)
+int	env_el_counter(t_minishell *minish, bool val_null_flag)
 {
 	size_t	env_elements;
 	t_var	*current;
@@ -65,7 +65,16 @@ int	env_el_counter(t_minishell *minish)
 	current = minish->var;
 	while (current)
 	{
-		env_elements++;
+		if (current->type == VAR_ENV)
+		{
+			if (val_null_flag)
+				env_elements++;
+			else
+			{
+				if (current->val != NULL)
+					env_elements++;
+			}
+		}
 		current = current->next;
 	}
 	return (env_elements);
@@ -75,16 +84,11 @@ char	*get_key_from_minish(t_minishell *minish, t_var *current)
 {
 	char	*key;
 
-	if (current->type == VAR_ENV)
+	key = ft_strdup(current->key);
+	if (key == NULL)
 	{
-		key = ft_strdup(current->key);
-		if (key == NULL)
-		{
-			minish->error_kind = ERR_MALLOC;
-			return (NULL);
-		}
+		minish->error_kind = ERR_MALLOC;
+		return (NULL);
 	}
-	else
-		key = NULL;
 	return (key);
 }

--- a/test/e2e/case/builtin_export.in
+++ b/test/e2e/case/builtin_export.in
@@ -60,4 +60,7 @@ export | grep GGG
 env | grep GGG
 BBBB=123
 export AAAA=123
+export | grep AAAA
+export | grep BBBB
 env | grep AAAA
+env | grep BBBB

--- a/test/e2e/case/builtin_export.in
+++ b/test/e2e/case/builtin_export.in
@@ -39,19 +39,25 @@ export ?a=_1 ?b=2
 echo $?
 export a=_1 ?b=2
 echo $?
-AAA=99
-export AAA
 export CCC
 export | grep CCC
+env | grep CCC
 export DDD
 DDD=dkdk
 export | grep DDD
+env | grep DDD
 export EEE
 export EEE=llll
 export | grep EEE
+env | grep EEE
 export FFF
 export FFF
 export | grep FFF
+env | grep FFF
 export GGG=123
 export GGG
 export | grep GGG
+env | grep GGG
+BBBB=123
+export AAAA=123
+env | grep AAAA

--- a/test/unit/src/variable/env.cpp
+++ b/test/unit/src/variable/env.cpp
@@ -55,10 +55,11 @@ TEST(Variable, get_key_list)
 
   const char *envp[] = {"HOME=/home", "USER=me", "PATH=/usr/bin",
                         "ENV=", "ENV2=a=b=c", NULL};
-  const char *expect[] = {"HOME", "USER", "PATH",
+  const char *expect[] = {"USER", "PATH",
                           "ENV", "ENV2", NULL};
   init_minishell(&minish);
   set_envp(&minish, envp);
+  set_type(&minish, "HOME", VAR_SHELL);
   char **actual = get_key_list(&minish);
   for (size_t i = 0; expect[i]; ++i)
   {

--- a/test/unit/src/variable/var.cpp
+++ b/test/unit/src/variable/var.cpp
@@ -12,7 +12,7 @@ TEST(Variable, add)
 {
   t_minishell minish;
   const char *expect[] = {"HOME=/home", "USER=me", "PATH=/usr/bin",
-                          "ENV1=", "ENV3=", "ENV2=a=b=c", NULL};
+                          "ENV1=", "ENV2=a=b=c", NULL};
   char **actual;
 
   init_minishell(&minish);
@@ -20,6 +20,7 @@ TEST(Variable, add)
   add_or_update_var(&minish, "USER", "me", VAR_ENV);
   add_or_update_var(&minish, "PATH", "/usr/bin", VAR_ENV);
   add_or_update_var(&minish, "ENV1", "", VAR_ENV);
+  // varがNULLの場合はget_envpで取得しない
   add_or_update_var(&minish, "ENV3", NULL, VAR_ENV);
   add_or_update_var(&minish, "ENV2", "a=b=c", VAR_ENV);
   actual = get_envp(&minish);
@@ -44,6 +45,7 @@ TEST(Variable, update)
   set_envp(&minish, envp);
   add_or_update_var(&minish, "ENV1", "update", VAR_ENV);
   add_or_update_var(&minish, "ENV", "add", VAR_ENV);
+  // varがNULLの場合は更新しない
   add_or_update_var(&minish, "ENV2", NULL, VAR_ENV);
   actual = get_envp(&minish);
   for (size_t i = 0; expect[i]; ++i)


### PR DESCRIPTION
- get_envp関数でvalがNULLの場合はskipするように修正
- VAL_SHELLの場合、envp[]にNULLを入れてしまっていたのでNULLを入れないように修正
fix #133 