### PR TITLE
メモリリーク修正

### DIFF
--- a/include/parser/expansion.h
+++ b/include/parser/expansion.h
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/07 16:58:41 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/10 12:19:33 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/11 17:51:53 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,8 +30,8 @@ typedef struct s_expansion
 }					t_expansion;
 
 int					init_expansion(t_expansion *exp, t_token *tok);
+int					free_expansion_and_return_error(t_expansion *exp);
 int					expansion_done(t_expansion *exp);
-bool				is_special_param(t_expansion *exp);
 bool				has_quotes(t_token *tok);
 void				update_inside_status(t_expansion *exp);
 
@@ -42,6 +42,7 @@ int					join_var(t_expansion *exp, const char *var, size_t var_len);
 int					expand_variable(t_minishell *minish, t_expansion *exp);
 int					consume_and_join_dollar(t_expansion *exp);
 
+bool				is_special_param(t_expansion *exp);
 int					expand_special_param(t_minishell *minish, t_expansion *exp);
 
 char				*expand(t_minishell *minish, t_token *tok);

--- a/src/parser/expansion_join.c
+++ b/src/parser/expansion_join.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/06 19:45:27 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/10 12:17:13 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/11 17:54:23 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,14 +42,14 @@ int	join_up_to_terminator(t_expansion *exp, t_inside_status in_status,
 		return (0);
 	word = ft_substr(exp->str, exp->n, num);
 	if (!word)
-		return (1);
+		return (free_expansion_and_return_error(exp));
 	tmp = exp->ret;
 	exp->ret = ft_strjoin(exp->ret, word);
 	if (!exp->ret)
 	{
 		free(word);
 		free(tmp);
-		return (1);
+		return (free_expansion_and_return_error(exp));
 	}
 	free(word);
 	free(tmp);
@@ -67,7 +67,7 @@ int	join_var(t_expansion *exp, const char *var, size_t var_len)
 		exp->ret = ft_strjoin(exp->ret, var);
 		if (!exp->ret)
 		{
-			return (1);
+			return (free_expansion_and_return_error(exp));
 		}
 		free(tmp);
 	}

--- a/src/parser/expansion_special.c
+++ b/src/parser/expansion_special.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/06 19:45:27 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/10 13:07:19 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/11 17:49:14 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,20 @@
 #include "minishell.h"
 #include "parser/expansion.h"
 #include <stdlib.h>
+
+bool	is_special_param(t_expansion *exp)
+{
+	if (exp->str[exp->i] != '$')
+		return (false);
+	if (ft_isdigit(exp->str[exp->i + 1]) || exp->str[exp->i + 1] == '#'
+		|| exp->str[exp->i + 1] == '$' || exp->str[exp->i + 1] == '*'
+		|| exp->str[exp->i + 1] == '@' || exp->str[exp->i + 1] == '?'
+		|| exp->str[exp->i + 1] == '-' || exp->str[exp->i + 1] == '!')
+	{
+		return (true);
+	}
+	return (false);
+}
 
 int	expand_special_param(t_minishell *minish, t_expansion *exp)
 {

--- a/src/parser/expansion_utils.c
+++ b/src/parser/expansion_utils.c
@@ -6,12 +6,13 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/06 19:45:27 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/10 12:16:20 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/11 17:55:41 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 #include "parser/expansion.h"
+#include <stdlib.h>
 
 int	init_expansion(t_expansion *exp, t_token *tok)
 {
@@ -26,23 +27,15 @@ int	init_expansion(t_expansion *exp, t_token *tok)
 	return (0);
 }
 
+int	free_expansion_and_return_error(t_expansion *exp)
+{
+	free(exp->ret);
+	return (1);
+}
+
 int	expansion_done(t_expansion *exp)
 {
 	return (exp->i >= exp->len);
-}
-
-bool	is_special_param(t_expansion *exp)
-{
-	if (exp->str[exp->i] != '$')
-		return (false);
-	if (ft_isdigit(exp->str[exp->i + 1]) || exp->str[exp->i + 1] == '#'
-		|| exp->str[exp->i + 1] == '$' || exp->str[exp->i + 1] == '*'
-		|| exp->str[exp->i + 1] == '@' || exp->str[exp->i + 1] == '?'
-		|| exp->str[exp->i + 1] == '-' || exp->str[exp->i + 1] == '!')
-	{
-		return (true);
-	}
-	return (false);
 }
 
 bool	has_quotes(t_token *tok)

--- a/src/parser/expansion_variable.c
+++ b/src/parser/expansion_variable.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/06 19:45:27 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/10 12:14:10 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/11 17:53:23 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -71,7 +71,8 @@ int	expand_variable(t_minishell *minish, t_expansion *exp)
 	key = extract_key(minish, exp);
 	if (!no_error(minish))
 	{
-		return (1);
+		free(key);
+		return (free_expansion_and_return_error(exp));
 	}
 	if (!key)
 	{

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 17:37:32 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/09 17:46:51 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/11 16:18:40 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,11 +44,11 @@ int	parse(t_minishell *minish)
 		node = command(minish);
 		if (!node)
 			return (1);
+		cur->next = node;
+		cur = node;
 		if (!check_syntax(minish))
 			break ;
 		consume(minish, "|");
-		cur->next = node;
-		cur = node;
 	}
 	minish->node = head.next;
 	input_heredoc(minish);


### PR DESCRIPTION
fix #124
下記2件のメモリリークを修正しました。
- syntaxエラー時のメモリリーク
```
ls | | cat
```

- 変数展開時にエラーが発生した場合のメモリリーク
```
AA="a a"
> $AA
```
