### PR TITLE
セミコロンのバグ修正

### DIFF
--- a/src/parser/token.c
+++ b/src/parser/token.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 17:20:20 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/08 15:52:31 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/12 15:44:30 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,7 @@
 
 bool	is_reserved(char p)
 {
-	return (p == '<' || p == '>' || p == '|' || p == ';');
+	return (p == '<' || p == '>' || p == '|');
 }
 
 bool	is_word_char(char p, t_inside_status in_status)
@@ -55,9 +55,9 @@ t_inside_status	update_in_status(char p, t_inside_status in_status)
 ssize_t	count_token_word_len(char *p)
 {
 	char			*q;
-	bool			is_continue;
 	t_inside_status	in_status;
 
+	bool is_continue ;
 	in_status = IN_NONE;
 	q = p;
 	while (*p != '\n' && *p != '\0')

--- a/src/parser/token.c
+++ b/src/parser/token.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 17:20:20 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/12 15:44:30 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/12 16:08:23 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,9 +55,9 @@ t_inside_status	update_in_status(char p, t_inside_status in_status)
 ssize_t	count_token_word_len(char *p)
 {
 	char			*q;
+	bool			is_continue;
 	t_inside_status	in_status;
 
-	bool is_continue ;
 	in_status = IN_NONE;
 	q = p;
 	while (*p != '\n' && *p != '\0')

--- a/test/e2e/case/permission.err
+++ b/test/e2e/case/permission.err
@@ -1,6 +1,6 @@
-minishell: ../bin/ls: permission denied
-minishell: ../bin: is a directory
-minishell: case/data/read_only: is a directory
-minishell: ./: is a directory
-minishell: ./abc: No such file or directory
-minishell: hello: command not found
+../bin/ls
+../bin
+case/data/read_only
+./
+./abc
+hello

--- a/test/e2e/case/permission.expected
+++ b/test/e2e/case/permission.expected
@@ -1,0 +1,6 @@
+minishell: ../bin/ls: permission denied
+minishell: ../bin: is a directory
+minishell: case/data/read_only: is a directory
+minishell: ./: is a directory
+minishell: ./abc: No such file or directory
+minishell: hello: command not found

--- a/test/e2e/case/permission.in
+++ b/test/e2e/case/permission.in
@@ -1,6 +1,0 @@
-../bin/ls
-../bin
-case/data/read_only
-./
-./abc
-hello

--- a/test/e2e/case/semicolon.err
+++ b/test/e2e/case/semicolon.err
@@ -1,4 +1,5 @@
-ls;
-ls ;
+;
+cat;
+cat ;
 ls | cat | cat;
 ls | cat | cat ;

--- a/test/e2e/case/semicolon.err
+++ b/test/e2e/case/semicolon.err
@@ -1,0 +1,4 @@
+ls;
+ls ;
+ls | cat | cat;
+ls | cat | cat ;

--- a/test/e2e/case/semicolon.err
+++ b/test/e2e/case/semicolon.err
@@ -1,5 +1,2 @@
 ;
 cat;
-cat ;
-ls | cat | cat;
-ls | cat | cat ;

--- a/test/e2e/case/semicolon.expected
+++ b/test/e2e/case/semicolon.expected
@@ -1,5 +1,2 @@
 minishell: ;: command not found
 minishell: cat;: command not found
-cat: ;: No such file or directory
-minishell: cat;: command not found
-cat: ;: No such file or directory

--- a/test/e2e/case/semicolon.expected
+++ b/test/e2e/case/semicolon.expected
@@ -1,4 +1,5 @@
-minishell: ls;: command not found
-ls: ;: No such file or directory
+minishell: ;: command not found
+minishell: cat;: command not found
+cat: ;: No such file or directory
 minishell: cat;: command not found
 cat: ;: No such file or directory

--- a/test/e2e/case/semicolon.expected
+++ b/test/e2e/case/semicolon.expected
@@ -1,0 +1,4 @@
+minishell: ls;: command not found
+ls: ;: No such file or directory
+minishell: cat;: command not found
+cat: ;: No such file or directory

--- a/test/e2e/case/syntax.err
+++ b/test/e2e/case/syntax.err
@@ -1,4 +1,4 @@
-minishell: syntax error near unexpected token `|'
-minishell: syntax error near unexpected token `|'
-minishell: syntax error near unexpected token `|'
-minishell: syntax error near unexpected token `|'
+| ls | cat
+ls | | cat
+ls | cat | cat | | cat
+ls | cat |

--- a/test/e2e/case/syntax.expected
+++ b/test/e2e/case/syntax.expected
@@ -1,0 +1,4 @@
+minishell: syntax error near unexpected token `|'
+minishell: syntax error near unexpected token `|'
+minishell: syntax error near unexpected token `|'
+minishell: syntax error near unexpected token `|'

--- a/test/e2e/case/syntax.in
+++ b/test/e2e/case/syntax.in
@@ -1,4 +1,0 @@
-| ls | cat
-ls | | cat
-ls | cat | cat | | cat
-ls | cat |

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -7,6 +7,7 @@ NC='\033[0m' # No Color
 
 all_tests_passed=true
 
+# 出力結果をbashと比較
 for test_case in case/*.in; do
   # ファイル名を取得（拡張子除く）
   filename=$(basename -- "$test_case")
@@ -16,37 +17,43 @@ for test_case in case/*.in; do
   ../../minishell < "$test_case" > "out/${filename}_minishell.out" 2> "out/${filename}_minishell.err"
   bash < "$test_case" > "out/${filename}_bash.out" 2> "out/${filename}_bash.err"
 
-  # 出力を比較
   diff "out/${filename}_minishell.out" "out/${filename}_bash.out" > out/${filename}.diff
   if [ $? -eq 0 ]; then
     echo -e "${GREEN}passed${NC}:\t$filename"
   else
-  	echo "---------------------------------------- diff ----------"
+    echo "---------------------------------------- diff ----------"
     cat "out/${filename}.diff"
-  	echo "---------------------------------------- minishell -----"
+    echo "---------------------------------------- minishell -----"
     cat "out/${filename}_minishell.out"
-	  echo "---------------------------------------- bash ----------"
+    echo "---------------------------------------- bash ----------"
     cat "out/${filename}_bash.out"
-  	echo "--------------------------------------------------------"
+    echo "--------------------------------------------------------"
     echo -e "${RED}failed${NC}:\t$filename"
     all_tests_passed=false
   fi
+done
 
-  # エラー予測があればエラー結果を比較
-  if [ ! -f "case/${filename}.err" ]; then
-    continue
-  fi
-  diff "out/${filename}_minishell.err" "case/${filename}.err" > out/${filename}.err.diff
+# エラー結果を予測と比較
+for test_case in case/*.err; do
+  # ファイル名を取得（拡張子除く）
+  filename=$(basename -- "$test_case")
+  filename="${filename%.*}"
+
+  # minishellとbashを実行
+  ../../minishell < "$test_case" > "out/${filename}_minishell.out" 2> "out/${filename}_minishell.err"
+  bash < "$test_case" > "out/${filename}_bash.out" 2> "out/${filename}_bash.err"
+
+  diff "out/${filename}_minishell.err" "case/${filename}.expected" > out/${filename}.err.diff
   if [ $? -eq 0 ]; then
     echo -e "${GREEN}passed${NC}:\t$filename(error)"
   else
-  	echo "---------------------------------------- diff(error) ----------"
+    echo "---------------------------------------- diff(error) ----------"
     cat "out/${filename}.err.diff"
-  	echo "---------------------------------------- minishell(error) -----"
+    echo "---------------------------------------- minishell(error) -----"
     cat "out/${filename}_minishell.err"
-  	echo "---------------------------------------- expected(error) ------"
-    cat "case/${filename}.err"
-	  echo "---------------------------------------------------------------"
+    echo "---------------------------------------- expected(error) ------"
+    cat "case/${filename}.expected"
+    echo "---------------------------------------------------------------"
     echo -e "${RED}failed${NC}:\t$filename(error)"
     all_tests_passed=false
   fi


### PR DESCRIPTION
fix #141
## セミコロンを文字列として解釈
昔、セミコロンを実装しようとして、やっぱりやめたことを忘れていました。
セミコロンはただの文字として解釈するように修正しました。

## E2Eテスト改良
以前のE2Eテストではbashとの出力結果を比較し、
その後に、エラーの予測があれば、エラーの比較をするようになっていましたが、
ls;
のようなケースの場合、bashとの比較をしてしまうとテストに失敗してしまうため、
エラー予測はエラーメッセージだけ比較するように修正しました。
