### PR TITLE
mallocエラーが表示されてしまうバグ修正

### DIFF
--- a/include/parser/parser.h
+++ b/include/parser/parser.h
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 14:19:35 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/09 13:07:55 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/12 17:23:16 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,7 @@ bool	expect_word(t_minishell *minish);
 bool	at_eof(t_token *tok);
 bool	at_pipe(t_token *tok);
 
-void	redirection(t_minishell *minish, t_node **redirect_cur);
+int		redirection(t_minishell *minish, t_node **redirect_cur);
 void	declaration(t_minishell *minish, t_node **declare_cur);
 t_node	*command(t_minishell *minish);
 

--- a/src/parser/heredoc_input.c
+++ b/src/parser/heredoc_input.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   heredoc_input.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
+/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/15 15:43:15 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/08 18:36:11 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/04/12 17:31:03 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -110,6 +110,8 @@ void	input_heredoc(t_minishell *minish)
 {
 	size_t	i;
 
+	if (!no_error(minish))
+		return ;
 	i = 0;
 	while (i < minish->heredoc.num)
 	{

--- a/src/parser/parser_command.c
+++ b/src/parser/parser_command.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 17:37:32 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/11 12:39:50 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/12 17:23:20 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -80,7 +80,8 @@ static void	expand_and_set_argv(t_node *node, t_minishell *minish)
 static void	parse_token(t_minishell *minish, t_node *node,
 		t_node **redirect_cur, t_node **declare_cur)
 {
-	redirection(minish, redirect_cur);
+	if (redirection(minish, redirect_cur))
+		return ;
 	if (node->argc == 0 && is_var_declaration(minish->cur_token->str,
 			minish->cur_token->len))
 	{

--- a/src/parser/parser_redirect.c
+++ b/src/parser/parser_redirect.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 17:37:32 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/09 14:20:29 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/12 17:23:13 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,7 +56,7 @@ static t_node	*new_redirect_node(t_node_kind kind, t_minishell *minish)
 	return (node);
 }
 
-void	redirection(t_minishell *minish, t_node **redirect_cur)
+int	redirection(t_minishell *minish, t_node **redirect_cur)
 {
 	t_node	*node;
 
@@ -82,4 +82,5 @@ void	redirection(t_minishell *minish, t_node **redirect_cur)
 		(*redirect_cur)->next = node;
 		*redirect_cur = node;
 	}
+	return (!no_error(minish));
 }

--- a/test/e2e/case/syntax.err
+++ b/test/e2e/case/syntax.err
@@ -2,3 +2,5 @@
 ls | | cat
 ls | cat | cat | | cat
 ls | cat |
+AA="a a"
+> $AA

--- a/test/e2e/case/syntax.err
+++ b/test/e2e/case/syntax.err
@@ -4,3 +4,4 @@ ls | cat | cat | | cat
 ls | cat |
 AA="a a"
 > $AA
+cat << EOF | cat << EOF2 | | cat << EOF3

--- a/test/e2e/case/syntax.expected
+++ b/test/e2e/case/syntax.expected
@@ -3,3 +3,4 @@ minishell: syntax error near unexpected token `|'
 minishell: syntax error near unexpected token `|'
 minishell: syntax error near unexpected token `|'
 minishell: $AA: ambiguous redirect
+minishell: syntax error near unexpected token `|'

--- a/test/e2e/case/syntax.expected
+++ b/test/e2e/case/syntax.expected
@@ -2,3 +2,4 @@ minishell: syntax error near unexpected token `|'
 minishell: syntax error near unexpected token `|'
 minishell: syntax error near unexpected token `|'
 minishell: syntax error near unexpected token `|'
+minishell: $AA: ambiguous redirect


### PR DESCRIPTION
fix #125 
fix #132 

エラー発生時に処理が中断されず、後続の処理に進んでしまい、
mallocエラーが表示されるバグについて、
適切に処理を中断するように修正しました。

## ambiguous redirectエラー
```
minishell $ AA="a a"
minishell $ > $AA
minishell: $AA: ambiguous redirect
```

## heredoc + syntaxエラー
```
minishell $ cat << EOF | cat << EOF2 | | cat << EOF3
minishell: syntax error near unexpected token `|'
```
bashではsyntax エラーの発生場所までheredocを読み込むことになっているのですが、
（つまりEOF, EOF2のheredocまでは読み込むが、EOF3のheredocは読み込まない）
大幅に改修が必要で断念しました。

zshではsyntaxエラーが発生したら、heredocは読み込まないことになっているし、
syntaxエラーがある場合、heredocで読み込んだところで、そのデータはどこにも使われないので、
それでなんとかディフェンスしようと思います。

- zshの場合
```
susumuyagi% cat << EOF | cat << EOF2 | | cat << EOF3
zsh: parse error near `|'
susumuyagi%
```
- bashの場合
```
bash-3.2$ cat << EOF | cat << EOF2 | | cat << EOF3
bash: syntax error near unexpected token `|'
> EOF
> EOF2
bash-3.2$ 
```


