### PR TITLE
">|"でエラーが2件表示されるバグ修正

### DIFF
--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 17:37:32 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/11 16:18:40 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/15 10:32:05 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,8 @@
 
 static bool	check_syntax(t_minishell *minish)
 {
+	if (!no_error(minish))
+		return (false);
 	if (at_pipe(minish->cur_token) && (at_pipe(minish->cur_token->next)
 			|| at_eof(minish->cur_token->next)))
 	{
@@ -43,7 +45,7 @@ int	parse(t_minishell *minish)
 	{
 		node = command(minish);
 		if (!node)
-			return (1);
+			break ;
 		cur->next = node;
 		cur = node;
 		if (!check_syntax(minish))

--- a/test/e2e/case/syntax.err
+++ b/test/e2e/case/syntax.err
@@ -5,3 +5,5 @@ ls | cat |
 AA="a a"
 > $AA
 cat << EOF | cat << EOF2 | | cat << EOF3
+>|$AA
+>|

--- a/test/e2e/case/syntax.expected
+++ b/test/e2e/case/syntax.expected
@@ -4,3 +4,5 @@ minishell: syntax error near unexpected token `|'
 minishell: syntax error near unexpected token `|'
 minishell: $AA: ambiguous redirect
 minishell: syntax error near unexpected token `|'
+minishell: syntax error near unexpected token `|'
+minishell: syntax error near unexpected token `|'


### PR DESCRIPTION
fix #144 

issueの下記事象は、
bashの場合は">|"というリダイレクト演算子があるため、ambiguous redirectとなりますが、
minishellの場合は「リダイレクト＋パイプ」と解釈し、syntaxエラーとするのが正しいと思います。
現在の仕様で問題ないと判断しました。
```
minishell $ AA="ls ls"
minishell $ >| $AA

bash-3.2$ AA="ls ls"
bash-3.2$ >| $AA
bash: $AA: ambiguous redirect
```

しかし、>|だけの場合、syntaxエラーが2行表示されていたため、修正しました。
```
minishell $ >|
minishell: syntax error near unexpected token `|'
minishell: syntax error near unexpected token `|'
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved error handling in parsing functions to enhance application stability.

- **Tests**
	- Updated syntax error tests to align with new parsing rules, ensuring more accurate error detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->