### PR TITLE
ctrl + 「\」対応

### DIFF
--- a/include/signal/signal.h
+++ b/include/signal/signal.h
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/22 12:16:18 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/03/31 18:48:34 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/04/15 17:28:19 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,6 +20,7 @@
 # define CTRL_C 1
 
 void	ctrl_c_handler(int sig);
+void	ctrl_backslash_handler(int sig);
 void	ctrl_c_blank_line_handler(t_minishell *minish);
 void	ctrl_d_clean_handler(t_minishell *minish);
 

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 13:22:07 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/31 19:09:05 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/04/15 17:26:51 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,6 +37,7 @@ int	main(int argc, const char **argv, const char **envp)
 	minish.argc = argc;
 	minish.argv = argv;
 	signal(SIGINT, ctrl_c_handler);
+	signal(SIGQUIT, ctrl_backslash_handler);
 	rl_event_hook = event;
 	if (argc > 1)
 	{

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/15 13:22:07 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/15 17:26:51 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/04/15 18:22:56 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,6 +36,7 @@ int	main(int argc, const char **argv, const char **envp)
 	init_minishell(&minish);
 	minish.argc = argc;
 	minish.argv = argv;
+	rl_catch_signals = 0;
 	signal(SIGINT, ctrl_c_handler);
 	signal(SIGQUIT, ctrl_backslash_handler);
 	rl_event_hook = event;

--- a/src/signal/signal.c
+++ b/src/signal/signal.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   signal.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
+/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/22 12:15:51 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/04/02 16:46:21 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/15 17:27:58 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,6 +32,11 @@ void	ctrl_c_handler(int sig)
 	g_signal = CTRL_C;
 	rl_replace_line("", 0);
 	rl_done = 1;
+}
+
+void	ctrl_backslash_handler(int sig)
+{
+	(void)sig;
 }
 
 void	ctrl_c_blank_line_handler(t_minishell *minish)


### PR DESCRIPTION
ctrl + 「\」が押された時にminishellを終了せず、何もしないように修正しました
fix #147 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
    - `SIGQUIT` 用のハンドラーを追加して、シグナル処理機能を拡張しました。

- **ドキュメント**
    - シグナル処理のソースファイルで著者名を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->