### PR TITLE
builtinのリダイレクトが動かいないバグ修正

### DIFF
--- a/src/exec/pipe.c
+++ b/src/exec/pipe.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/12 12:06:41 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/10 14:49:36 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/16 17:23:34 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,21 +32,22 @@ static void	init_pipe(t_minishell *minish, t_node **node, int *prev_fds,
 static int	connect_io(t_minishell *minish, t_node *node, int prev_fds[],
 		int fds[])
 {
-	if (node->pid == RUN_PARENT)
-		return (0);
-	if (node != minish->node)
+	if (node->pid != RUN_PARENT)
 	{
-		close(STDIN_FILENO);
-		dup2(prev_fds[0], STDIN_FILENO);
-		close(prev_fds[0]);
-		close(prev_fds[1]);
-	}
-	if (node->next != NULL)
-	{
-		close(fds[0]);
-		close(STDOUT_FILENO);
-		dup2(fds[1], STDOUT_FILENO);
-		close(fds[1]);
+		if (node != minish->node)
+		{
+			close(STDIN_FILENO);
+			dup2(prev_fds[0], STDIN_FILENO);
+			close(prev_fds[0]);
+			close(prev_fds[1]);
+		}
+		if (node->next != NULL)
+		{
+			close(fds[0]);
+			close(STDOUT_FILENO);
+			dup2(fds[1], STDOUT_FILENO);
+			close(fds[1]);
+		}
 	}
 	if (redirect(minish, node))
 	{

--- a/test/e2e/case/parser.in
+++ b/test/e2e/case/parser.in
@@ -4,7 +4,7 @@ FILE2=$DIR/file2.txt
 echo $FILE1 '"$DIR"$DIR' "'$FILE1'"
 ls -al *.in > $FILE1 > $FILE2
 ls $FILE1 $FILE2
-cat<$FILE1|ls -al|cat|cat
+cat<$FILE1|ls -a|cat|cat
 echo $?
 cat $FILE2
 echo $?

--- a/test/e2e/case/redirect.in
+++ b/test/e2e/case/redirect.in
@@ -1,0 +1,9 @@
+FILE1=out/redirect1.txt
+FILE2=out/redirect2.txt
+echo "abc" > $FILE1
+echo $? $FILE1 $PWD >> $FILE1
+ls -a >> $FILE1
+env | sort | grep -v "_=" | grep -v "OLDPWD=" | grep -v "SHLVL=" > $FILE2
+export | grep -v "declare -x SHLVL=" | grep -v "declare -x _=" | grep -v "declare -x OLDPWD" >> $FILE2
+cat $FILE1 $FILE2
+rm $FILE1 $FILE2


### PR DESCRIPTION
fix #151

Norm対応の時にバグを埋め込んでしまいました。
builtinの時でもリダイレクトが動くように修正しました。

ついでに、
parserのE2Eテストの中に
ls -al
の結果を比較するケースがあり、
bashとminishellの実行時刻によって結果が異なりエラーとなることがあるので
ls -a
に変更しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- プロセスの入出力リダイレクションの管理を改善しました。

- **バグ修正**
	- `ls` コマンドのオプションを `-al` から `-a` に変更し、スクリプトの出力が修正されました。

- **テスト**
	- 新しいエンドツーエンドテストスクリプトを追加し、出力を複数ファイルにリダイレクトする機能を試験しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->