### PR TITLE
include修正

### DIFF
--- a/include/signal/signal.h
+++ b/include/signal/signal.h
@@ -6,14 +6,14 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/22 12:16:18 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/04/15 17:28:19 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/04/16 22:22:12 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef SIGNAL_H
 # define SIGNAL_H
 
-# include "../minishell.h"
+# include "minishell.h"
 # include "readline.h"
 # include <signal.h>
 

--- a/src/builtin/builtin_echo.c
+++ b/src/builtin/builtin_echo.c
@@ -6,20 +6,18 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/23 19:23:01 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/13 13:43:00 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/04/16 22:20:48 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 #include "minishell.h"
 #include <stdlib.h>
-// TODO 後で消す
-#include <stdio.h>
 #include <unistd.h>
 
 static void	print_arg(t_node *node, int start)
 {
-	int		i;
+	int	i;
 
 	i = start;
 	while (node->argv[i] != NULL)

--- a/src/builtin/builtin_env.c
+++ b/src/builtin/builtin_env.c
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/23 19:23:01 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/13 00:09:13 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/04/16 22:20:56 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,8 +17,6 @@
 #include "variable/var.h"
 #include <stdlib.h>
 #include <unistd.h>
-// TODO 後で消す
-#include <stdio.h>
 
 int	builtin_env(t_minishell *minish, t_node *node)
 {

--- a/src/builtin/builtin_pwd.c
+++ b/src/builtin/builtin_pwd.c
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/23 19:23:01 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/03/19 17:18:50 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/04/16 22:25:27 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,6 +33,6 @@ int	builtin_pwd(t_minishell *minish, t_node *node)
 		}
 		minish->pwd = pathname;
 	}
-	printf("%s\n", minish->pwd);
+	ft_printf_fd(STDOUT_FILENO, "%s\n", minish->pwd);
 	return (node->wait_status);
 }

--- a/src/exec/find_path.c
+++ b/src/exec/find_path.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   find_path.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
+/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/21 12:26:12 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/08 17:00:42 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/16 22:21:14 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,7 +15,6 @@
 #include "utils/minishell_error.h"
 #include "utils/utils.h"
 #include "variable/env.h"
-#include <stdio.h>
 #include <stdlib.h>
 
 static int	find_path(t_node *node, char **path_array)

--- a/src/exec/redirect.c
+++ b/src/exec/redirect.c
@@ -3,21 +3,20 @@
 /*                                                        :::      ::::::::   */
 /*   redirect.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
+/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/12 12:06:41 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/08 11:55:38 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/16 22:21:19 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtin/builtin.h"
+#include "libft.h"
 #include "message/message.h"
 #include "minishell.h"
 #include "parser/heredoc.h"
-#include <fcntl.h>
-// #include <stdio.h>
-#include "libft.h"
 #include <errno.h>
+#include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/src/parser/heredoc_input.c
+++ b/src/parser/heredoc_input.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   heredoc_input.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
+/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/15 15:43:15 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/12 17:31:03 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/16 22:21:25 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,7 +16,6 @@
 #include "readline.h"
 #include "signal/signal.h"
 #include "utils/minishell_error.h"
-#include <stdio.h>
 #include <stdlib.h>
 
 static char	*expand_line(t_minishell *minish, char *line, char *doc, int idx)

--- a/test/e2e/case/builtin_pwd.in
+++ b/test/e2e/case/builtin_pwd.in
@@ -1,3 +1,3 @@
 pwd
 pwd a b c
-
+pwd | pwd | pwd 


### PR DESCRIPTION
fix #153 
ほんとですね。。。
テスターがずっと前から合っていたということですね。。。大変失礼いたしました。
stdio.hを削除しましたが3箇所残しています。
- get_next_line.c
「EOF」を使用するため
- get_next_line_utils.c
「EOF」を使用するため
- minishell.h
   ダウンロードしてくるreadline.hが「File」typeを必要としており、その際にstdio.hが必要
signal.hでreadline.hをincludeしているのですが、formatしてしまうとreadline.hの後にstdio.h読み込んでしまうため
ビルドエラーになってしまいます
そのため、signal.hでは読み込まず、minishell.hで読み込むようにしています。
（minishell.hで読み込ませると色々なところでprintfとか使えてしまうのであまり良くないとは思っているのですが、、、）