### PR TITLE
heredoc + redirectのバグ修正

### DIFF
--- a/src/exec/redirect.c
+++ b/src/exec/redirect.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   redirect.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
+/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/12 12:06:41 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/16 22:21:19 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/04/19 16:33:07 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -95,7 +95,7 @@ int	redirect(t_minishell *minish, t_node *node)
 			is_error = redirect_append(redirect_node->path);
 		else if (redirect_node->kind == ND_HEREDOC)
 		{
-			if (!is_builtin(node) && redirect_node->next == NULL)
+			if (!(is_builtin(node) && !node->in_pipe))
 				is_error = write_heredoc(minish, redirect_node->heredoc_idx);
 		}
 		if (is_error)


### PR DESCRIPTION
fix #156

下記が動かないバグを修正しました。
```
minishell $ cat << EOF > text
```

issueで他に色々書きましたが、僕の勘違いでbashと同じ動作なので、他の部分は問題なさそうでした。
heredocのE2Eテストができないため、テストケーツは追加していません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ビルトインコマンドとパイプ処理の条件を改善しました。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->