### PR TITLE
$"", $''を実装しました

### DIFF
--- a/include/parser/expansion.h
+++ b/include/parser/expansion.h
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/07 16:58:41 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/18 14:51:05 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/19 17:19:30 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,6 +35,7 @@ typedef struct s_expansion
 	size_t			n;
 
 	t_inside_status	in_status;
+	bool			in_heredoc;
 }					t_expansion;
 
 int					init_expansion(t_expansion *exp, const char *str,

--- a/src/parser/expansion.c
+++ b/src/parser/expansion.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/06 19:45:27 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/18 14:51:30 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/19 17:25:59 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -123,6 +123,7 @@ char	*expand_heredoc(t_minishell *minish, const char *str)
 	{
 		return (occurred_malloc_error_return_null(minish));
 	}
+	exp.in_heredoc = true;
 	while (!done_expansion(&exp))
 	{
 		if (expand_special_param(minish, &exp))

--- a/src/parser/expansion_utils.c
+++ b/src/parser/expansion_utils.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/06 19:45:27 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/18 13:52:24 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/19 17:20:10 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,6 +30,7 @@ int	init_expansion(t_expansion *exp, const char *str, size_t len)
 	exp->i = 0;
 	exp->n = 0;
 	exp->in_status = IN_NONE;
+	exp->in_heredoc = false;
 	return (0);
 }
 

--- a/src/parser/expansion_variable.c
+++ b/src/parser/expansion_variable.c
@@ -6,7 +6,7 @@
 /*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/06 19:45:27 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/17 18:09:30 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/19 17:26:51 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,12 +55,39 @@ int	consume_and_join_dollar(t_expansion *exp)
 	return (0);
 }
 
+static bool	dollar_quote(t_expansion *exp)
+{
+	if (exp->in_heredoc)
+	{
+		return (false);
+	}
+	if (exp->in_status == IN_NONE && ft_strncmp("$'", &exp->str[exp->i],
+			2) == 0)
+	{
+		exp->in_status = IN_QUOTE;
+		exp->i += 2;
+		exp->n = exp->i;
+		return (true);
+	}
+	if (exp->in_status == IN_NONE && ft_strncmp("$\"", &exp->str[exp->i],
+			2) == 0)
+	{
+		exp->in_status = IN_D_QUOTE;
+		exp->i += 2;
+		exp->n = exp->i;
+		return (true);
+	}
+	return (false);
+}
+
 int	expand_variable(t_minishell *minish, t_expansion *exp, bool need_split)
 {
 	int		ret;
 	char	*key;
 
 	if (!(exp->in_status == IN_NONE || exp->in_status == IN_D_QUOTE))
+		return (0);
+	if (dollar_quote(exp))
 		return (0);
 	if (is_special_param(exp))
 		return (0);

--- a/src/parser/heredoc_input.c
+++ b/src/parser/heredoc_input.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   heredoc_input.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
+/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/15 15:43:15 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/16 22:21:25 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/04/19 17:05:23 by susumuyagi       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,13 +25,12 @@ static char	*expand_line(t_minishell *minish, char *line, char *doc, int idx)
 	if (minish->heredoc.need_expansion[idx])
 	{
 		ret = expand_heredoc(minish, line);
+		free(line);
 		if (!ret)
 		{
-			free(line);
 			free(doc);
 			return (NULL);
 		}
-		free(line);
 	}
 	else
 	{

--- a/test/e2e/case/expansion3.in
+++ b/test/e2e/case/expansion3.in
@@ -1,0 +1,16 @@
+AA="  123  456  "
+echo $"$AA"
+echo $'$AA'
+echo $"$"AA""
+echo $'$'AA''
+echo $"$HOME"
+echo $'$HOME'
+echo $"HOME"
+echo $'HOME'
+echo $"$""$"$"$'"
+echo $'$''$'$'$"'
+echo $"$"HOME""
+echo $'$'HOME''
+echo $"$"$""
+echo $"$"""
+echo $'$'''


### PR DESCRIPTION
fix #149

$ " "は" "、$ ' 'は' 'と解釈するようにしました。
ただし、heredocの中では解釈しません。
```
minishell $ echo $"HOME"
HOME
minishell $ cat << EOF
> $"HOME"
> EOF
$"HOME"
minishell $ 

bash-3.2$ echo $"HOME"
HOME
bash-3.2$ cat << EOF
> $"HOME"
> EOF
$"HOME"
bash-3.2$ 
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ヒアドキュメント内の状態を追跡する新しい機能が追加されました。
	- シェルスクリプトの変数展開と引用に関する新しいテストケースが導入されました。

- **バグ修正**
	- ヒアドキュメントの展開後に適切なメモリクリーンアップを行うように修正されました。

- **テスト**
	- 変数展開とドル引用に関連するテストケースが更新され、さまざまな文字列操作と展開の正しい動作を保証します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->