### PR TITLE
topコマンド中にSIGQUITシグナル受け取った時に表示がおかしくなる対応

### DIFF
--- a/src/exec/exec.c
+++ b/src/exec/exec.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exec.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susumuyagi <susumuyagi@student.42.fr>      +#+  +:+       +#+        */
+/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/19 16:23:27 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/01 15:27:58 by susumuyagi       ###   ########.fr       */
+/*   Updated: 2024/04/20 13:22:35 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,7 @@
 #include "exec/pipe.h"
 #include "exec/process.h"
 #include "minishell.h"
+#include <termios.h>
 #include <unistd.h>
 
 static void	save_orig_io(int orig_io[2])
@@ -34,15 +35,18 @@ static void	restore_orig_io(int orig_io[2])
 
 void	exec(t_minishell *minish)
 {
-	int	orig_io[2];
+	int				orig_io[2];
+	struct termios	term;
 
 	if (minish->node == NULL)
 		return ;
 	if (set_cmd_path(minish))
 		return ;
 	save_orig_io(orig_io);
+	tcgetattr(STDIN_FILENO, &term);
 	exec_pipe(minish);
 	wait_prosesses(minish);
+	tcsetattr(STDIN_FILENO, TCSANOW, &term);
 	restore_orig_io(orig_io);
 	set_status_code(minish);
 }

--- a/src/exec/exec.c
+++ b/src/exec/exec.c
@@ -6,7 +6,7 @@
 /*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/19 16:23:27 by susumuyagi        #+#    #+#             */
-/*   Updated: 2024/04/20 13:22:35 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/04/20 13:36:15 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,6 +38,7 @@ void	exec(t_minishell *minish)
 	int				orig_io[2];
 	struct termios	term;
 
+	term = (struct termios){0};
 	if (minish->node == NULL)
 		return ;
 	if (set_cmd_path(minish))


### PR DESCRIPTION
fix #150 以下の事象対応
```
612   Electron     0.0  00:14.99 36    1    418   55M    0B    29M    612  1    sleepinQuit: 3
                                                                                              minishell $
minishell: fjsdlkdk: command not found
                                      minishell $
```

- topコマンドの子プロセスを作成する前に端末情報を保存
- 子プロセスが終了したら端末情報を元に戻す
- ctrl \で終了後、１回目の表示はちょっとおかしいですが、2回目以降は正しく表示されます
- structの宣言をしてよかったか微妙なところです
- signalを受け取ったらどうこうするではなく、いかなる操作をする時にでも通ってしまうところにコード変更してしまいました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- `exec` 関数内でのターミナルI/O設定の取り扱いが向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->